### PR TITLE
Fix the homebrew can't load config issue in MacOS

### DIFF
--- a/etc/scripts/redis-stack-server.macos
+++ b/etc/scripts/redis-stack-server.macos
@@ -30,7 +30,7 @@ if [ -d /usr/local/var ]; then
         REDIS_DATA_DIR=${_datadir}
     fi
 elif [ -d /opt/homebrew/var ]; then
-    BREW_BASE=/usr/local
+    BREW_BASE=/opt/homebrew
     _datadir=/opt/homebrew/var/db/redis-stack
     mkdir -p ${_datadir}
     touch ${_datadir}/.testfile 2>&1


### PR DESCRIPTION
Fix the default path for homebrew when install in MacOS, so the redis-stack-server can load the default redis-stack.conf under /opt/homebrew/etc/redis-stack.conf