### PR TITLE
Latest master cherry picks [6.2]

### DIFF
--- a/.github/workflows/APPIMAGE_REUSABLE.yml
+++ b/.github/workflows/APPIMAGE_REUSABLE.yml
@@ -32,11 +32,7 @@ on:
       fpmversion:
         required: false
         type: string
-<<<<<<< HEAD
-        default: 1.14.1
-=======
         default: 1.14.2
->>>>>>> origin/master
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true

--- a/.github/workflows/APPIMAGE_REUSABLE.yml
+++ b/.github/workflows/APPIMAGE_REUSABLE.yml
@@ -32,7 +32,11 @@ on:
       fpmversion:
         required: false
         type: string
+<<<<<<< HEAD
         default: 1.14.1
+=======
+        default: 1.14.2
+>>>>>>> origin/master
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -107,7 +111,7 @@ jobs:
           ./pkg2appimage.AppImage `pwd`/etc/redis-stack-server.appimage
           mv out/redis-stack-server-*.AppImage out/${{matrix.package}}-${{steps.get_version.outputs.VERSION}}-${{inputs.arch}}.AppImage
           for i in `ls out/*.AppImage`; do
-            sha256 $i | awk '{print $1}' > $i.sha256
+            sha256sum $i | awk '{print $1}' > $i.sha256
           done
 
 #      - name: validate packages

--- a/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
+++ b/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
@@ -45,7 +45,7 @@ on:
       fpmversion:
         required: false
         type: string
-        default: 1.14.1
+        default: 1.14.2
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true

--- a/.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+++ b/.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
@@ -3,37 +3,64 @@ name: Build and Publish
 on:
   workflow_call:
     inputs:
+
+      # docker image for compiling redis
       image_name:
         required: true
         type: string
+
+      # architecture
       arch:
         required: false
         type: string
         default: x86_64
+
+      # short version of the OS (ubuntu20.04, rhel7, etc)
       osnick:
         required: true
         type: string
+
+      # target package type (deb, rpm, etc)
       target:
         required: true
         type: string
+
+      # a different type of OS shortname (focal, rhel7, etc)
       platform:
         required: true
         type: string
+
+      # an override - if set, use only as the target in testing
+      testplatform:
+        required: false
+        type: string
+
+      # operating system name (i.e Linux)
       osname:
         required: true
         type: string
+
+      # build depenedncies with the package install statement
       build_deps:
         required: true
         type: string
+
+      # a string to apt packaging dependencies
       packaging_deps:
         required: true
         type: string
+
+      # redis version to compile
       redisversion:
         required: false
         type: string
+
+      # prcompiled redis package version to try downloading
       packagedredisversion:
         required: false
         type: string
+
+      # self explanatory
       pythonversion:
         required: false
         type: string
@@ -45,7 +72,9 @@ on:
       fpmversion:
         required: false
         type: string
-        default: 1.14.1
+        default: 1.14.2
+
+    # for AWS and code signing
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -90,7 +119,7 @@ jobs:
       id: redis-already-built
       continue-on-error: true
       run: |
-        wget https://redismodules.s3.amazonaws.com/redis-stack/dependencies/redis-${{inputs.packagedredisversion}}-${{inputs.osname}}-$${{inputs.osnick}}-${{inputs.arch}}.tgz
+        wget https://redismodules.s3.amazonaws.com/redis-stack/dependencies/redis-${{inputs.packagedredisversion}}-${{inputs.osname}}-${{inputs.osnick}}-${{inputs.arch}}.tgz
     - uses: actions/checkout@v2
       if: steps.redis-already-built.outcome != 'success'
       with:
@@ -151,6 +180,7 @@ jobs:
       fpmversion: ${{inputs.fpmversion}}
       rubyversion: ${{inputs.rubyversion}}
       platform: ${{inputs.platform}}
+      testplatform: ${{inputs.testplatform}}
       osname: ${{inputs.osname}}
       osnick: ${{inputs.osnick}}
       arch: ${{inputs.arch}}
@@ -247,14 +277,16 @@ jobs:
           keygrip=`gpg -k --with-keygrip |sed -n 5p|cut -d '=' -f 2-2`
           echo "::set-output name=GPG_KEYGRIP::$keygrip"
 
-      - name: gpg sign package
-        if: steps.iamafork.outputs.IAMAFORK == 'false'
+      - name: gpg sign deb package
+        if: steps.iamafork.outputs.IAMAFORK == 'false' && inputs.target == 'deb'
         run: |
-          if [ -f /usr/bin/dpkg-sig ]; then
-            echo '${{secrets.GPG_PASSWORD}}' > .passfile
-            dpkg-sig -g '--pinentry-mode loopback --passphrase-file .passfile --batch' -s redis -k ${{steps.get_gpg_id.outputs.GPG_ID}} *.deb
-            rm -f .passfile
-          elif [ -f /usr/bin/rpm ]; then
+          echo '${{secrets.GPG_PASSWORD}}' > .passfile
+          dpkg-sig -g '--pinentry-mode loopback --passphrase-file .passfile --batch' -s redis -k ${{steps.get_gpg_id.outputs.GPG_ID}} *.deb
+          rm -f .passfile
+
+      - name: gpg sign rpm package
+        if: steps.iamafork.outputs.IAMAFORK == 'false' && inputs.target == 'rpm'
+        run: |
             gpg --export -a '${{ steps.get_gpg_email.outputs.GPG_EMAIL }}' > key
             rpm --import key
             echo allow-preset-passphrase > ~/.gnupg/gpg-agent.conf
@@ -262,7 +294,6 @@ jobs:
             /usr/lib/gnupg/gpg-preset-passphrase -P '${{ secrets.GPG_PASSWORD }}' -c --preset ${{ steps.get_gpg_keygrip.outputs.GPG_KEYGRIP }}
             rpmsign --addsign --key-id ${{ steps.get_gpg_id.outputs.GPG_ID}} *.rpm
             rm key
-          fi
 
       - name: run tests in dockers
         run: |
@@ -271,16 +302,41 @@ jobs:
           cp *.tar.gz redis-stack/${{ matrix.package }}.tar.gz
           cp *.${{ env.target }} redis-stack/${{ matrix.package }}.${{ env.target }}
           # pytest -m "${{env.platform}} and not physical and not arm"
-          invoke test -m ${{env.platform}} -n physical -n arm
+          if [ -z ${{env.testplatform }} ]; then
+            invoke test -m ${{env.platform}} -n physical -n arm
+          else
+            invoke test -m ${{env.testplatform}} -n physical -n arm
+          fi
 
-      - name: perist ${{env.target}} package
+      - uses: dorny/test-reporter@v1
+        if: success() || failure()
+        with:
+          name: Test Results ${{env.platform}} ${{env.osnick}} ${{env.arch}}
+          path: '*.xml'
+          reporter: java-junit
+          list-suites: all
+          list-tests: all
+          max-annotations: 10
+
+      - name: persist ${{env.target}} package
         uses: actions/upload-artifact@v2
+        if: env.testplatform == ''
         with:
           name: ${{ matrix.package }}-${{env.platform}}-${{env.arch}}.${{env.target}}
           path: |
             ${{ matrix.package }}*.${{env.target}}
-      - name: perist tarball
+
+      - name: persist ${{env.target}} package
         uses: actions/upload-artifact@v2
+        if: env.testplatform != ''
+        with:
+          name: ${{ matrix.package }}-${{env.testplatform}}-${{env.arch}}.${{env.target}}
+          path: |
+            ${{ matrix.package }}*.${{env.target}}
+
+      - name: persist tarball
+        uses: actions/upload-artifact@v2
+        if: env.testplatform == ''
         with:
           name: ${{ matrix.package }}-${{env.platform}}-${{env.arch}}.tar.gz
           path: |
@@ -290,7 +346,11 @@ jobs:
         continue-on-error: true
         run: |
           mkdir -p s3uploads
-          cp *.${{env.target}} *.tar.gz s3uploads
+          if [ -z ${{env.testplatform }} ]; then
+            cp *.${{env.target}} *.tar.gz s3uploads
+          else
+            cp *.${{env.target}} s3uploads
+          fi
           cd s3uploads
           for i in `ls`; do
             sha256sum $i |awk '{print $1}' > $i.sha256

--- a/.github/workflows/DOCKER_REUSABLE.yml
+++ b/.github/workflows/DOCKER_REUSABLE.yml
@@ -88,7 +88,7 @@ jobs:
       - name: generate docker file
         run: |
           source .venv/bin/activate
-          invoke dockergen -d ${{ matrix.package }}
+          invoke dockergen -p ${{ matrix.package }}
 
       - name: Log in to DockerHub
         uses: docker/login-action@v1

--- a/.github/workflows/REDISINSIGHT_WEB_REUSABLE.yml
+++ b/.github/workflows/REDISINSIGHT_WEB_REUSABLE.yml
@@ -30,7 +30,7 @@ on:
       fpmversion:
         required: false
         type: string
-        default: 1.14.1
+        default: 1.14.2
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true

--- a/.github/workflows/SNAP_REUSABLE.yml
+++ b/.github/workflows/SNAP_REUSABLE.yml
@@ -28,7 +28,7 @@ on:
       fpmversion:
         required: false
         type: string
-        default: 1.14.1
+        default: 1.14.2
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -84,14 +84,14 @@ jobs:
           source .venv/bin/activate
           invoke package -o ${{inputs.osname}} -s ${{inputs.osnick}} -d ${{inputs.platform}} -a ${{inputs.arch}} -t ${{env.target}} -p ${{ matrix.package }}
           for i in `ls *.snap`; do
-            sha256 $i | awk '{print $1}' > $i.sha256
+            sha256sum $i | awk '{print $1}' > $i.sha256
           done
 
 #      - name: validate packages
 #        run: |
 #          mkdir redis-stack
 #          cp *.snap redis-stack/${{ matrix.package }}.${{ env.target }}
-#          sudo .venv/bin/pytest -m snaps
+#          sudo invoke test -m snaps
 
       - uses: s3-actions/s3cmd@v1.1
         if: steps.iamafork.outputs.IAMAFORK == 'false'

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -28,7 +28,7 @@ jobs:
      build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip
      packaging_deps: sudo apt-get install -y unzip dpkg-sig curl gnupg2
      redisversion: 6.2.7
-     packagedredisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -102,7 +102,7 @@ jobs:
      build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
      packaging_deps: sudo apt-get install -y unzip dpkg-sig curl gnupg2
      redisversion: 6.2.7
-     packagedredisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -157,7 +157,7 @@ jobs:
      build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
      packaging_deps: sudo apt-get install -y unzip dpkg-sig curl gnupg2
      redisversion: 6.2.7
-     packagedredisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -177,7 +177,29 @@ jobs:
      build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
      packaging_deps: sudo apt-get install -y unzip dpkg-sig curl gnupg2
      redisversion: 6.2.7
-     packagedredisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
+     pythonversion: "3.10"
+   secrets:
+     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+     GPG_KEY: ${{ secrets.GPG_KEY }}
+     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+
+  # uses precompiled ubuntu binaries, hence the testplatform override
+ x86_64-archlinux:
+   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+   with:
+     image_name: archlinux:latest
+     platform: focal
+     testplatform: archlinux
+     osnick: ubuntu20.04
+     arch: x86_64
+     osname: Linux
+     target: pkg
+     build_deps: pacman -Syyu --noconfirm gcc gcc-libs git openssl jq wget python python-pip openssh make
+     packaging_deps: sudo apt-get install -y unzip dpkg-sig curl gnupg2 libarchive-tools
+     redisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -197,7 +219,7 @@ jobs:
      build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
      packaging_deps: sudo apt-get install -y unzip dpkg-sig curl gnupg2
      redisversion: 6.2.7
-     packagedredisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -219,7 +241,7 @@ jobs:
       yum install -y gcc make jemalloc-devel openssl-devel python3 python3-pip jq wget
      packaging_deps: sudo apt-get install -y rpm unzip gpg gnupg2 curl
      redisversion: 6.2.7
-     packagedredisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -242,7 +264,7 @@ jobs:
        dnf install -y gcc make jemalloc-devel openssl-devel tar git python3 python3-pip jq wget
      packaging_deps: sudo apt-get install -y rpm unzip curl gnupg2
      redisversion: 6.2.7
-     packagedredisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -262,9 +284,9 @@ jobs:
      platform: catalina
      osname: macos
      redisversion: 6.2.7
-     packagedredisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
-     fpmversion: 1.14.1
+     fpmversion: 1.14.2
      rubyversion: 2.7.2
 
    runs-on: macos-latest
@@ -281,7 +303,7 @@ jobs:
      id: redis-already-built
      continue-on-error: true
      run: |
-       wget https://redismodules.s3.amazonaws.com/redis-stack/dependencies/redis-${{inputs.packagedredisversion}}-${{inputs.osname}}-$${{inputs.osnick}}-${{inputs.arch}}.tgz
+       wget https://redismodules.s3.amazonaws.com/redis-stack/dependencies/redis-${{env.packagedredisversion}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz
    - uses: ruby/setup-ruby@v1
      with:
        ruby-version: ${{env.rubyversion}}
@@ -389,11 +411,6 @@ jobs:
        cd redis-stack
        source .venv/bin/activate
        invoke package -o ${{env.osname}} -s ${{env.osnick}} -d ${{env.platform}} -a ${{env.arch}} -r ../redis/src -t zip -p redis-stack-server -k fetch
-       for i in `ls *.zip`; do
-         sha256sum $i |awk '{print $1}' > $i.sha256
-       done
-       mkdir s3dist
-       cp *.zip *.sha256 s3dist
 
    - name: perist the zipfile
      uses: actions/upload-artifact@v2
@@ -448,7 +465,7 @@ jobs:
      uses: actions/checkout@v2
    - name: install dependencies
      run: |
-       brew install libomp openssl
+       brew install libomp openssl coreutils
        poetry install
    - name: gather artifacts
      uses: actions/download-artifact@v2
@@ -460,9 +477,20 @@ jobs:
        ls -R
        mkdir -p redis-stack
        unzip redis-stack/redis-stack*.${{env.target}} -d redis-stack/redis-stack-server
+
    - name: run osx tests
      run: |
-       .venv/bin/pytest -m macos
+       .venv/bin/pytest -m macos --junit-xml=results.xml
+   - uses: dorny/test-reporter@v1
+     if: success() || failure()
+     with:
+       name: Test Results ${{env.platform}} ${{env.osnick}} ${{env.arch}}
+       path: '*.xml'
+       reporter: java-junit
+       list-suites: all
+       list-tests: all
+       max-annotations: 10
+
    - name: get package version
      id: get_version
      run: |
@@ -482,8 +510,12 @@ jobs:
    - name: persist redis to s3
      if: steps.iamafork.outputs.IAMAFORK == 'false'
      run: |
-       s3cmd put -P redis-stack/redis-stack-server*.${{env.target}} \
-       s3://redismodules/redis-stack/snapshots/redis-stack-server-${{steps.get_version.outputs.VERSION}}.${{env.osnick}}.${{env.arch}}.${{env.target}}
+      mkdir s3dist
+      cp redis-stack/redis-stack*.${{env.target}} s3dist
+      for i in `ls s3dist`; do
+        sha256sum $i | awk '{print $1'} > s3dist/$i.sha256
+      done
+      s3cmd put -P s3dist/* s3://redismodules/redis-stack/snapshots/
 
  # the m1 requires a zip file so that homebrew can unpack it
  build-package-osx-m1:
@@ -495,9 +527,9 @@ jobs:
      platform: monterey
      osname: macos
      redisversion: 6.2.7
-     packagedredisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
-     fpmversion: 1.14.1
+     fpmversion: 1.14.2
      rubyversion: 2.7.2
    runs-on: macos-latest
    steps:
@@ -510,6 +542,9 @@ jobs:
      uses: actions/setup-python@v3
      with:
        python-version: "${{ env.pythonversion }}"
+   - name: install dependencies
+     run: |
+      brew install coreutils
    - name: install poetry
      uses: snok/install-poetry@v1
      with:
@@ -614,7 +649,7 @@ jobs:
        s3cmd put -P *.sha256 s3://redismodules/redis-stack/snapshots/
 
  test-osx-m1:
-   name: M1 tests
+   name: Mac (M1) tests
    needs: [build-package-osx-m1]
    env:
      arch: arm64
@@ -623,14 +658,14 @@ jobs:
      platform: monterey
      osname: macos
      redisversion: 6.2.7
-     packagedredisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
    runs-on: ubuntu-latest
    steps:
      - name: determine if in fork
        id: iamafork
        run: |
-         amfork=`cat /Users/runner/work/_temp/_github_workflow/event.json | jq '.pull_request.head.repo.fork'`
+         amfork=`cat /github/workflow/event.json | jq '.pull_request.head.repo.fork'`
          echo "am I fork: ${amfork}"
          echo "::set-output name=IAMAFORK::$amfork"
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,11 @@ Dockerfile.*
 *.tgz
 *.appimage
 *.AppImage
+*.tar.xz
+*.pkg
 
 *.rdb
 *.lock
 .vagrant
 *.log
+*.xml

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,41 @@
+REDIS SOURCE AVAILABLE LICENSE (RSAL) AGREEMENT
+
+Last Update: March 20, 2019
+
+This Agreement sets forth the terms on which the Licensor makes available the Software. BY INSTALLING, DOWNLOADING, ACCESSING, USING OR DISTRIBUTING ANY OF THE SOFTWARE, YOU AGREE TO THE TERMS AND CONDITIONS OF THIS AGREEMENT. IF YOU DO NOT AGREE TO SUCH TERMS AND CONDITIONS, YOU MUST NOT USE THE SOFTWARE. If you are receiving the Software on behalf of a legal entity, you represent and warrant that you have the actual authority to agree to the terms and conditions of this agreement on behalf of such entity.
+
+The terms below have the meanings set forth below for purposes of this Agreement: Agreement​: this Redis Source Available License Agreement.
+
+Database Product: any of the following products or services: (a) database; (b) caching engine; (c) stream processing engine; (d) search engine; (e) indexing engine; (f) machine learning or deep learning or artificial intelligence serving engine; (g) a product or service exposing the Redis API; (h) a product or service exposing the Redis Modules API; or (i) a product or service exposing the Software API.
+
+License: the Redis Source Available License described in Section 1.
+
+Licensor: as indicated in the source code license. Modification​:​ ​a modification of the Software made by You under the License, Section 1.1(c).
+
+Redis: the open source Redis software as described in redis.io.
+
+Software: certain software components designed to work with Redis and provided to you under this Agreement.
+
+You: the recipient of this Software, an individual, or the entity on whose behalf you are receiving the Software.
+
+Your Application: an application developed by or for You, where such application is not a Database Product.
+
+1.	LICENSE GRANT AND CONDITIONS
+
+	1.1. Subject to the terms and conditions of this Section 1, Licensor hereby grants to You a non-exclusive, royalty-free, worldwide, non-transferable license during the term of this Agreement to: (a) distribute ​or make available the Software or your Modifications under the terms of this Agreement, only as part of Your Application, so long as you include the following notice on any copy you distribute: “This software is subject to the terms of the Redis Source Available License Agreement”. (b) use​ the Software, or your Modifications, only as part of Your Application, but not in connection with any Database Product that is distributed or otherwise made available by any third party. (c) modify ​the Software, provided that Modifications remain subject to the terms of this License. (d) reproduce​ the Software as necessary for the above.
+
+	1.2. Sublicensing. You may sublicense the right to use the Software fully embedded in Your Application as distributed by you in accordance with Section 1.1(a), pursuant to a written license that disclaims all warranties and liabilities on behalf of Licensor.
+
+	1.3. Notices. On all copies of the Software that you make, you must retain all copyright or other proprietary notices.
+
+2.	TERM AND TERMINATION. This Agreement will continue unless and until earlier terminated as set forth herein. If You breach any of its conditions or obligations under this Agreement, this Agreement will terminate automatically and the licenses granted herein will terminate automatically.
+
+3.	INTELLECTUAL PROPERTY. As between the parties, Licensor retains all right, title, and interest in the Software, and to Redis or other Licensor trademarks or service marks, and all intellectual property rights therein. Licensor hereby reserves all rights not expressly granted to You in this Agreement.
+
+4.	DISCLAIMER. TO THE EXTENT ALLOWABLE UNDER LAW, LICENSOR HEREBY DISCLAIMS ANY AND ALL WARRANTIES AND CONDITIONS, EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE, WITH RESPECT TO THE SOFTWARE. Licensor has no obligation to support the Software.
+
+5.	LIMITATION OF LIABILITY. TO THE EXTENT ALLOWABLE UNDER LAW, LICENSOR WILL NOT BE LIABLE FOR ANY DAMAGES OF ANY KIND, INCLUDING BUT NOT LIMITED TO, LOST PROFITS OR ANY CONSEQUENTIAL, SPECIAL, INCIDENTAL, INDIRECT, OR DIRECT DAMAGES, ARISING OUT OF OR RELATING TO THIS AGREEMENT.
+
+6.	GENERAL. You are not authorized to assign Your rights under this Agreement to any third party. Licensor may freely assign its rights under this Agreement to any third party. This Agreement is the entire agreement between the parties on the subject matter hereof. No amendment or modification hereof will be valid or binding upon the parties unless made in writing and signed by the duly authorized representatives of both parties. In the event that any provision, including without limitation any condition, of this Agreement is held to be unenforceable, this Agreement and all licenses and rights granted hereunder will immediately terminate. Failure by Licensor to exercise any right hereunder will not be construed as a waiver of any subsequent breach of that right or as a waiver of any other right.
+
+This Agreement will be governed by and interpreted in accordance with the laws of the state of California, without reference to its conflict of laws principles. If You are located within the United States, all disputes arising out of this Agreement are subject to the exclusive jurisdiction of courts located in Santa Clara County, California. USA. If You are located outside of the United States, any dispute, controversy or claim arising out of or relating to this Agreement will be referred to and finally determined by arbitration in accordance with the JAMS before a single arbitrator in Santa Clara County, California. Judgment upon the award rendered by the arbitrator may be entered in any court having jurisdiction thereof.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,30 @@ This repository builds redis, and downloads various components (modules, RedisIn
 
 ----
 
+[Homebrew Recipe](https://github.com/redis-stack/homebrew-redis-stack) |
+[Helm Charts](https://github.com/redis-stack/helm-redis-stack) |
+[Docker images](https://hub.docker.com/r/redis/redis-stack) |
+[Other downloads](https://redis.io/download/#redis-stack-downloads)
+
+---
+
+## Quick start
+
+*Start a docker*
+ ```docker run redis/redis-stack:latest```
+
+*Start a docker with the custom password foo*
+ ```docker run -e REDIS_ARGS="--requirepass foo" redis/redis-stack:latest```
+
+*Start a docker with both custom redis arguments and a search configuration*
+```docker run -e REDIS_ARGS="--requirepass foo" -e REDISEARCH_ARGS="MAXSEARCHRESULTS 5" redis/redis-stack:latest```
+
+*From a locally installed package: start a redis stack with custom search results and passwords*
+
+```REDISEARCH_ARGS="MAXSEARCHRESULTS 5" redis-stack-server --requirepass foo```
+
+----
+
 ## Development Requirements
 
 * Python > 3.10 (for this toolkit) and [poetry](https://python-poetry.org)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = ["Your Name <you@example.com>"]
 license = "MIT"
 
 [tool.poetry.dependencies]
-python = ">=3.6.2,<4.0"
+python = ">=3.8,<4.0"
 PyYAML = "^6.0"
 isort = "^5.10.1"
 Fabric = "^2.7.0"
@@ -16,7 +16,7 @@ invoke = "^1.6.0"
 requests = "^2.27.1"
 loguru = "^0.6.0"
 Jinja2 = "^3.0.3"
-redis = "^4.3.1"
+redis = "^4.3.4"
 pytest = "^7.0.0"
 docker = "^5.0.3"
 flake8 = "^4.0.1"
@@ -28,6 +28,7 @@ markers = [
     "bionic: ubuntu bionic tests",
     "focal: ubuntu focal tests",
     "bullseye: bullseye tests",
+    "archlinux: archlinux tests",
     "rhel7: RedHat 7 (rhel7) tests",
     "rhel8: RedHat 8 (rhel8) tests",
     "physical: run tests only within a vagrant image",

--- a/stack/__main__.py
+++ b/stack/__main__.py
@@ -49,7 +49,7 @@ if __name__ == "__main__":
         help="Target package type (eg dpkg)",
         default="deb",
         type="choice",
-        choices=["rpm", "deb", "osxpkg", "pacman", "zip", "tar", "snap"],
+        choices=["rpm", "deb", "osxpkg", "pkg", "zip", "tar", "snap"],
     )
     p.add_option(
         "-p",

--- a/stack/recipes/__init__.py
+++ b/stack/recipes/__init__.py
@@ -119,7 +119,7 @@ class Recipe(object):
 
     def pacman(self, fpmargs, distribution):
         fpmargs.append(
-            f"-p {self.C.get_key(self.PACKAGE_NAME)['product']}-{self.version}.{distribution}.{self.ARCH}.pacman"
+            f"-p {self.C.get_key(self.PACKAGE_NAME)['product']}-{self.version}.{self.ARCH}.pkg"
         )
         fpmargs.append(
             f"--after-install {os.path.join(self.__PATHS__.SCRIPTDIR, 'package', 'postinstall')}"
@@ -130,9 +130,11 @@ class Recipe(object):
         fpmargs.append(
             f"--before-remove {os.path.join(self.__PATHS__.SCRIPTDIR, 'package', 'preremove')}"
         )
+        fpmargs.append("--depends openssl")
+        fpmargs.append("--depends gcc-libs")
         fpmargs.append(f"--pacman-user {self.C.get_key('product_user')}")
         fpmargs.append(f"--pacman-group {self.C.get_key('product_group')}")
-        fpmargs.append("--pacman-compression gz")
+        fpmargs.append("--pacman-compression xz")
         fpmargs.append("-t pacman")
         return fpmargs
 
@@ -234,7 +236,7 @@ class Recipe(object):
         elif package_type == "osxpkg":
             fpmargs = self.osxpkg(fpmargs, distribution)
 
-        elif package_type == "pacman":
+        elif package_type == "pkg":
             fpmargs = self.pacman(fpmargs, distribution)
         elif package_type == "zip":
             fpmargs = self.zip(fpmargs, distribution)

--- a/tasks.py
+++ b/tasks.py
@@ -65,7 +65,7 @@ def markhandler(marker=[], notmarker=[]):
 def test(c, marker=[], notmarker=[], filter="", version=None):
     """Run unit tests"""
     markstr = markhandler(marker, notmarker)
-    cmd = f"pytest -m '{markstr}' {filter} -s"
+    cmd = f"pytest -m '{markstr}' {filter} --junit-xml=results.xml -s"
     if version is not None:
         cmd = f"VERSION={version} {cmd}"
     sys.stderr.write(f"Running: {cmd}\n")
@@ -193,21 +193,21 @@ def package_redis(
 
 @task(
     help={
-        "docker_type": "docker type [redis-stack, redis-stack-server]",
+        "product": "docker type [redis-stack, redis-stack-server]",
         "arch": "architectures [x86_64, arm64]",
     }
 )
-def dockergen(c, docker_type="redis-stack", arch="x86_64"):
+def dockergen(c, product="redis-stack", arch="x86_64"):
     """Generate docker compile files"""
     here = os.path.abspath(os.path.dirname(__file__))
     src = os.path.join("envs", "dockers", "dockerfile.tmpl")
-    dest = os.path.join(here, "envs", "dockers", f"Dockerfile.{docker_type}")
+    dest = os.path.join(here, "envs", "dockers", f"Dockerfile.{product}")
     loader = jinja2.FileSystemLoader(here)
     env = jinja2.Environment(loader=loader)
     tmpl = loader.load(name=src, environment=env)
 
     p = Paths(None, None)
-    vars = {"docker_type": docker_type, "SHAREDIR": p.SHAREDIR, "arch": arch}
+    vars = {"docker_type": product, "SHAREDIR": p.SHAREDIR, "arch": arch}
     with open(dest, "w+") as fp:
         fp.write(tmpl.render(vars))
     sys.stdout.write(f"Docker file generated: {dest}\n")

--- a/tests/smoketest/helpers.py
+++ b/tests/smoketest/helpers.py
@@ -21,6 +21,7 @@ BINARIES = [
 ]
 
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+CONFIGYAML = os.path.join(ROOT, "config.yml")
 
 
 def stack_dockloader(cls):

--- a/tests/smoketest/test_archlinux.py
+++ b/tests/smoketest/test_archlinux.py
@@ -1,0 +1,26 @@
+import pytest
+
+from env import DockerTestEnv
+from mixins import RedisPackagingMixin, RedisTestMixin
+
+
+@pytest.mark.archlinux
+class TestArchPackage(DockerTestEnv, RedisTestMixin, RedisPackagingMixin, object):
+    
+    PLATFORM = "linux/amd64"
+    DOCKER_NAME = "archlinux:latest"
+    CONTAINER_NAME = "redis-stack-archlinux"
+    
+    def install(self, container):
+        
+        res, out = container.exec_run("pacman -Fy")
+        assert res == 0
+        
+        res, out = container.exec_run("pacman -U --noconfirm /build/redis-stack/redis-stack-server.pkg")
+        if res != 0:
+            raise IOError(out)
+    
+    def uninstall(self, container):
+        res, out = container.exec_run("pacman -R --noconfirm redis-stack-server")
+        if res != 0:
+            raise IOError(out)

--- a/tests/smoketest/test_baremetal.py
+++ b/tests/smoketest/test_baremetal.py
@@ -87,6 +87,7 @@ class TestBullseye(DebVagrant):
 
     OSNICK = "bullseye"
 
+
 @pytest.mark.rhel7
 @pytest.mark.physical
 class TestCentos7(RPMVagrant):

--- a/tests/smoketest/test_debs.py
+++ b/tests/smoketest/test_debs.py
@@ -61,6 +61,7 @@ class TestFocal(DEBTestBase):
     CONTAINER_NAME = "redis-stack-focal"
     PLATFORM = "linux/amd64"
 
+
 @pytest.mark.bullseye
 class TestBullseye(DEBTestBase):
 

--- a/tests/smoketest/test_dockers.py
+++ b/tests/smoketest/test_dockers.py
@@ -50,9 +50,10 @@ class TestARMRedisStack(TestRedisStack):
             try:
                 assert out.decode().strip().lower().find("redisinsight") != -1
             except AssertionError:  # if in docker we can't, validate process runs, trust team tests
-                res, out = self.container.exec_run("ps -ef") # there are no pipes in exec_run contexts
+                res, out = self.container.exec_run(
+                    "ps -ef"
+                )  # there are no pipes in exec_run contexts
                 assert out.decode().strip().lower().find("nodejs") != -1
-
 
 
 @pytest.mark.dockers_redis_stack_server

--- a/tests/smoketest/test_tars.py
+++ b/tests/smoketest/test_tars.py
@@ -122,3 +122,15 @@ class TestCentos8(TARTestBase):
             "yum install -y epel-release tar",
             "yum install -y openssl-devel jemalloc-devel libgomp",
         ]
+        
+@pytest.mark.archlinux
+class TestArchLinux(TARTestBase):
+
+    DOCKER_NAME = "archlinux:latest"
+    CONTAINER_NAME = "redis-stack-centos8"
+    PLATFORM = "linux/amd64"
+    
+    def __precommands__(self):
+        return [
+            "pacman -Fy"
+        ]


### PR DESCRIPTION
- RedisInsight 2.2.0 (#129)
- release rules changes (#128)
- removing edge, from release docker names (#132)
- redistimeseries 1.6.13 (#138)
- Update RedisBloom 2.2.17 (#141)
- Redis 7.0.2 (#142)
- Updating Redisinsight version for 2.4.0 (#144)
- Updating README with download links (#143)
- Adding the packages bucket as another release destination (#145)
- Unifying entrypoint script (#146)
- Adding helm chart to release process (#149)
- RedisTimeSeries 1.6.16 and RedisGraph 2.8.15 (#150)
- RediSearch 2.4.9 (#151)
- separating the manifests
- Arm snap image (#155)
- x86_64 AppImage Support (#154)
- nightly edge builds (#163)
- Upgrading build system to python 3.10 (#162)
- Fetch redis if built, or build (#166)
- redis 7.0.4 (#165)
- Updating RedisTimeSeries to 1.6.17 (#171)
- New RedisInsight version, and nodejs upgrade (#167)
- RediSearch 2.8.16, RedisGraph 2.4.11 (#174)
- Update RedisBloom v2.2.18 (#170)
- RedisJSON 2.2.0 (#175)
- RedisGraph 2.8.17 (#177)
- nightly credential check (#183)
- release paths for drafter (#184)
- README: highlight release process for RedisInsight
- Adding badges to README (#176)
- Green, forked PRs (#186)
- Fixing docker entrypoints for variable passing (#192)
- Ensuring armx linux, does not use jemalloc (#193)
- Adding README samples for running, and removing the double prefix on REDIS_ARGS (#194)
- Component upgrades (#196)
- adding link to latest and helm (#195)
- Labels with cleaner prefixes (#197)
- Updating the label for the helm chart.
- Quoting the paths in the entrypoint (#201)
- Upgrading FPM to 1.14.2 (#206)
- Support for archlinux packages (#205)
- Unit test to ensure versions are as set (#204)
- Consistency for dockergen arguments (#159)
- Create LICENSE (#207)
- Gathering test results (#208)
- Ensuring sha256 generating for missing packages (#209)
