### PR TITLE
enabling archlinux package in 6.2

### DIFF
--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -27,8 +27,8 @@ jobs:
      target: deb
      build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip
      packaging_deps: sudo apt-get install -y unzip dpkg-sig curl gnupg2
-     redisversion: 7.0.4
-     packagedredisversion: 7.0.4-1
+     redisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -101,8 +101,8 @@ jobs:
      target: deb
      build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
      packaging_deps: sudo apt-get install -y unzip dpkg-sig curl gnupg2
-     redisversion: 7.0.4
-     packagedredisversion: 7.0.4-1
+     redisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -156,8 +156,8 @@ jobs:
      target: deb
      build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
      packaging_deps: sudo apt-get install -y unzip dpkg-sig curl gnupg2
-     redisversion: 7.0.4
-     packagedredisversion: 7.0.4-1
+     redisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -176,8 +176,8 @@ jobs:
      target: deb
      build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
      packaging_deps: sudo apt-get install -y unzip dpkg-sig curl gnupg2
-     redisversion: 7.0.4
-     packagedredisversion: 7.0.4-1
+     redisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -185,27 +185,27 @@ jobs:
      GPG_KEY: ${{ secrets.GPG_KEY }}
      GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
-#  # uses precompiled ubuntu binaries, hence the testplatform override
-# x86_64-archlinux:
-#   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
-#   with:
-#     image_name: archlinux:latest
-#     platform: focal
-#     testplatform: archlinux
-#     osnick: ubuntu20.04
-#     arch: x86_64
-#     osname: Linux
-#     target: pkg
-#     build_deps: pacman -Syyu --noconfirm gcc gcc-libs git openssl jq wget python python-pip openssh make
-#     packaging_deps: sudo apt-get install -y unzip dpkg-sig curl gnupg2 libarchive-tools
-#     redisversion: 7.0.4
-#     packagedredisversion: 7.0.4-1
-#     pythonversion: "3.10"
-#   secrets:
-#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#     GPG_KEY: ${{ secrets.GPG_KEY }}
-#     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+  # uses precompiled ubuntu binaries, hence the testplatform override
+ x86_64-archlinux:
+   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+   with:
+     image_name: archlinux:latest
+     platform: focal
+     testplatform: archlinux
+     osnick: ubuntu20.04
+     arch: x86_64
+     osname: Linux
+     target: pkg
+     build_deps: pacman -Syyu --noconfirm gcc gcc-libs git openssl jq wget python python-pip openssh make
+     packaging_deps: sudo apt-get install -y unzip dpkg-sig curl gnupg2 libarchive-tools
+     redisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
+     pythonversion: "3.10"
+   secrets:
+     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+     GPG_KEY: ${{ secrets.GPG_KEY }}
+     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
  bullseye:
    uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
@@ -218,8 +218,8 @@ jobs:
      target: deb
      build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
      packaging_deps: sudo apt-get install -y unzip dpkg-sig curl gnupg2
-     redisversion: 7.0.4
-     packagedredisversion: 7.0.4-1
+     redisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -240,8 +240,8 @@ jobs:
       yum install -y epel-release
       yum install -y gcc make jemalloc-devel openssl-devel python3 python3-pip jq wget
      packaging_deps: sudo apt-get install -y rpm unzip gpg gnupg2 curl
-     redisversion: 7.0.4
-     packagedredisversion: 7.0.4-1
+     redisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
@@ -263,8 +263,8 @@ jobs:
        dnf install -y oracle-epel-release-el8
        dnf install -y gcc make jemalloc-devel openssl-devel tar git python3 python3-pip jq wget
      packaging_deps: sudo apt-get install -y rpm unzip curl gnupg2
-     redisversion: 7.0.4
-     packagedredisversion: 7.0.4-1
+     redisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -283,8 +283,8 @@ jobs:
      target: zip
      platform: catalina
      osname: macos
-     redisversion: 7.0.4
-     packagedredisversion: 7.0.4-1
+     redisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
      fpmversion: 1.14.2
      rubyversion: 2.7.2
@@ -526,8 +526,8 @@ jobs:
      target: zip
      platform: monterey
      osname: macos
-     redisversion: 7.0.4
-     packagedredisversion: 7.0.4-1
+     redisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
      fpmversion: 1.14.2
      rubyversion: 2.7.2
@@ -578,7 +578,7 @@ jobs:
 #    - name: build redis from source
 #      run: |
 #        cd redis
-#        make all BUILD_TLS=yes FINAL_LIBS="-lm -ldl ../deps/hiredis/libhiredis_ssl.a /usr/local/opt/openssl/lib/libssl.a /usr/local/opt/openssl/lib/libcrypto.a" CFLAGS="-I /opt/homebrew/opt/openssl@1.1/include"
+#        make all BUILD_TLS=yes FINAL_LIBS="-lm -ldl ../deps/hiredis/libhiredis_ssl.a /opt/homebrew/opt/openssl/lib/libssl.a /opt/homebrew/opt/openssl/lib/libcrypto.a" CFLAGS="-I /opt/homebrew/opt/openssl@3/include"
 #
    - name: collect dependencies prior to packaging
      run: |
@@ -657,8 +657,8 @@ jobs:
      target: zip
      platform: monterey
      osname: macos
-     redisversion: 7.0.4
-     packagedredisversion: 7.0.4-1
+     redisversion: 6.2.7
+     packagedredisversion: 6.2.7-1
      pythonversion: "3.10"
    runs-on: ubuntu-latest
    steps:

--- a/README.md
+++ b/README.md
@@ -87,6 +87,30 @@ This repository builds redis, and downloads various components (modules, RedisIn
 
 ----
 
+[Homebrew Recipe](https://github.com/redis-stack/homebrew-redis-stack) |
+[Helm Charts](https://github.com/redis-stack/helm-redis-stack) |
+[Docker images](https://hub.docker.com/r/redis/redis-stack) |
+[Other downloads](https://redis.io/download/#redis-stack-downloads)
+
+---
+
+## Quick start
+
+*Start a docker*
+ ```docker run redis/redis-stack:latest```
+
+*Start a docker with the custom password foo*
+ ```docker run -e REDIS_ARGS="--requirepass foo" redis/redis-stack:latest```
+
+*Start a docker with both custom redis arguments and a search configuration*
+```docker run -e REDIS_ARGS="--requirepass foo" -e REDISEARCH_ARGS="MAXSEARCHRESULTS 5" redis/redis-stack:latest```
+
+*From a locally installed package: start a redis stack with custom search results and passwords*
+
+```REDISEARCH_ARGS="MAXSEARCHRESULTS 5" redis-stack-server --requirepass foo```
+
+----
+
 ## Development Requirements
 
 * Python > 3.10 (for this toolkit) and [poetry](https://python-poetry.org)

--- a/stack/recipes/__init__.py
+++ b/stack/recipes/__init__.py
@@ -125,7 +125,7 @@ class Recipe(object):
         # so, if we have a non-master (or non fixed) release (i.e 6.2.4-v5)
         # we split accordingly, and reseed the version
         config = Config()
-        ver = config.get_key("version")[self.PACKAGE_NAME].split("-")
+        ver = config.get_key("versions")[self.PACKAGE_NAME].split("-")
         if len(ver) != 0:
             for idx, v in enumerate(fpmargs):
                 if v.find('--version') != -1:

--- a/stack/recipes/__init__.py
+++ b/stack/recipes/__init__.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import re
 
 import jinja2
 from loguru import logger
@@ -118,6 +119,21 @@ class Recipe(object):
         return fpmargs
 
     def pacman(self, fpmargs, distribution):
+        
+        # replace the version, due to an awesome - archlinux packaging bug
+        # we can't rely on the split in semver
+        # so, if we have a non-master (or non fixed) release (i.e 6.2.4-v5)
+        # we split accordingly, and reseed the version
+        config = Config()
+        ver = config.get_key("version")[self.PACKAGE_NAME].split("-")
+        if len(ver) != 0:
+            for idx, v in enumerate(fpmargs):
+                if v.find('--version') != -1:
+                    break
+            f = re.findall("[0-9]{1,3}", ver[1])
+            fpmargs[idx] = f"--version {ver}"
+            fpmargs.append(f"--iteration {f[0]}")
+        
         fpmargs.append(
             f"-p {self.C.get_key(self.PACKAGE_NAME)['product']}-{self.version}.{self.ARCH}.pkg"
         )

--- a/stack/recipes/__init__.py
+++ b/stack/recipes/__init__.py
@@ -131,7 +131,7 @@ class Recipe(object):
                 if v.find('--version') != -1:
                     break
             f = re.findall("[0-9]{1,3}", ver[1])
-            fpmargs[idx] = f"--version {ver}"
+            fpmargs[idx] = f"--version {ver[0]}"
             fpmargs.append(f"--iteration {f[0]}")
         
         fpmargs.append(

--- a/tests/smoketest/test_archlinux.py
+++ b/tests/smoketest/test_archlinux.py
@@ -6,9 +6,10 @@ from mixins import RedisPackagingMixin, RedisTestMixin
 
 @pytest.mark.archlinux
 class TestArchPackage(DockerTestEnv, RedisTestMixin, RedisPackagingMixin, object):
+<<<<<<< HEAD
 
     PLATFORM = "linux/amd64"
-    DOCKER_NAME = "archlinux:base-devel"
+    DOCKER_NAME = "archlinux:latest"
     CONTAINER_NAME = "redis-stack-archlinux"
 
     def install(self, container):
@@ -17,5 +18,10 @@ class TestArchPackage(DockerTestEnv, RedisTestMixin, RedisPackagingMixin, object
         assert res == 0
 
         res, out = container.exec_run("pacman -U --noconfirm /build/redis-stack/redis-stack-server.pkg")
+        if res != 0:
+            raise IOError(out)
+
+    def uninstall(self, container):
+        res, out = container.exec_run("pacman -R --noconfirm redis-stack-server")
         if res != 0:
             raise IOError(out)

--- a/tests/smoketest/test_archlinux.py
+++ b/tests/smoketest/test_archlinux.py
@@ -6,7 +6,6 @@ from mixins import RedisPackagingMixin, RedisTestMixin
 
 @pytest.mark.archlinux
 class TestArchPackage(DockerTestEnv, RedisTestMixin, RedisPackagingMixin, object):
-<<<<<<< HEAD
 
     PLATFORM = "linux/amd64"
     DOCKER_NAME = "archlinux:latest"


### PR DESCRIPTION
- RedisInsight 2.2.0 (#129)
- release rules changes (#128)
- removing edge, from release docker names (#132)
- redistimeseries 1.6.13 (#138)
- Update RedisBloom 2.2.17 (#141)
- Redis 7.0.2 (#142)
- Updating Redisinsight version for 2.4.0 (#144)
- Updating README with download links (#143)
- Adding the packages bucket as another release destination (#145)
- Unifying entrypoint script (#146)
- Adding helm chart to release process (#149)
- RedisTimeSeries 1.6.16 and RedisGraph 2.8.15 (#150)
- RediSearch 2.4.9 (#151)
- separating the manifests
- Arm snap image (#155)
- x86_64 AppImage Support (#154)
- nightly edge builds (#163)
- Upgrading build system to python 3.10 (#162)
- Fetch redis if built, or build (#166)
- redis 7.0.4 (#165)
- Updating RedisTimeSeries to 1.6.17 (#171)
- New RedisInsight version, and nodejs upgrade (#167)
- RediSearch 2.8.16, RedisGraph 2.4.11 (#174)
- Update RedisBloom v2.2.18 (#170)
- RedisJSON 2.2.0 (#175)
- RedisGraph 2.8.17 (#177)
- nightly credential check (#183)
- release paths for drafter (#184)
- README: highlight release process for RedisInsight
- Adding badges to README (#176)
- Green, forked PRs (#186)
- Fixing docker entrypoints for variable passing (#192)
- Ensuring armx linux, does not use jemalloc (#193)
- Adding README samples for running, and removing the double prefix on REDIS_ARGS (#194)
- Component upgrades (#196)
- adding link to latest and helm (#195)
- Labels with cleaner prefixes (#197)
- Updating the label for the helm chart.
- Quoting the paths in the entrypoint (#201)
- Upgrading FPM to 1.14.2 (#206)
- Support for archlinux packages (#205)
- Unit test to ensure versions are as set (#204)
- Consistency for dockergen arguments (#159)
- Create LICENSE (#207)
- Gathering test results (#208)
- Ensuring sha256 generating for missing packages (#209)
- New versions of modules (#211)
- Redis 7.0.5 (#220)
- marking docker as latest based on a variable (#221)
- ISLATEST is in caps, for the latest push. (#223)
