### PR TITLE
archlinux package in 7.0

### DIFF
--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -185,26 +185,27 @@ jobs:
      GPG_KEY: ${{ secrets.GPG_KEY }}
      GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
-# x86_64-archlinux:
-#   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
-#   with:
-#     image_name: archlinux:latest
-#     platform: focal
-#     testplatform: archlinux
-#     osnick: ubuntu20.04
-#     arch: x86_64
-#     osname: Linux
-#     target: pkg
-#     build_deps: pacman -Syyu --noconfirm gcc gcc-libs git openssl jq wget python python-pip openssh make
-#     packaging_deps: sudo apt-get install -y unzip dpkg-sig curl gnupg2 libarchive-tools
-#     redisversion: 7.0.5
-#     packagedredisversion: 7.0.5-1
-#     pythonversion: "3.10"
-#   secrets:
-#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#     GPG_KEY: ${{ secrets.GPG_KEY }}
-#     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+  # uses precompiled ubuntu binaries, hence the testplatform override
+ x86_64-archlinux:
+   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+   with:
+     image_name: archlinux:latest
+     platform: focal
+     testplatform: archlinux
+     osnick: ubuntu20.04
+     arch: x86_64
+     osname: Linux
+     target: pkg
+     build_deps: pacman -Syyu --noconfirm gcc gcc-libs git openssl jq wget python python-pip openssh make
+     packaging_deps: sudo apt-get install -y unzip dpkg-sig curl gnupg2 libarchive-tools
+     redisversion: 7.0.5
+     packagedredisversion: 7.0.5-1
+     pythonversion: "3.10"
+   secrets:
+     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+     GPG_KEY: ${{ secrets.GPG_KEY }}
+     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
  bullseye:
    uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,9 @@ env:
   # Distination bucket for releases
   s3publicreponame: s3://packages.redis.io/redis-stack
 
+  # set to YES (in caps) so that in the specified branch, the release will mark as latest
+  ISLATEST: no
+
 jobs:
 
   promote_releases:
@@ -70,15 +73,18 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: publish redis-stack docker
+        if: ${{ env.ISLATEST == 'YES' }}
         run: |
-          docker manifest create redis/redis-stack:${{steps.get_version.outputs.VERSION}} \
+          docker manifest create redis/redis-stack:latest \
               redisfab/redis-stack:${{steps.get_version.outputs.VERSION}}-x86_64 \
               redisfab/redis-stack:${{steps.get_version.outputs.VERSION}}-arm64
-          docker manifest push redis/redis-stack:${{ steps.get_version.outputs.VERSION}}
+          docker manifest push redis/redis-stack:latest
       - name: publish redis-stack-server docker
+        if: ${{ env.ISLATEST == 'YES' }}
         run: |
-          docker manifest create redis/redis-stack-server:${{steps.get_version.outputs.VERSION}} \
+          docker manifest create redis/redis-stack-server:latest \
               redisfab/redis-stack-server:${{steps.get_version.outputs.VERSION}}-x86_64 \
               redisfab/redis-stack-server:${{steps.get_version.outputs.VERSION}}-arm64
-          docker manifest push redis/redis-stack-server:${{ steps.get_version.outputs.VERSION}}
+          docker manifest push redis/redis-stack-server:latest

--- a/README.md
+++ b/README.md
@@ -87,6 +87,30 @@ This repository builds redis, and downloads various components (modules, RedisIn
 
 ----
 
+[Homebrew Recipe](https://github.com/redis-stack/homebrew-redis-stack) |
+[Helm Charts](https://github.com/redis-stack/helm-redis-stack) |
+[Docker images](https://hub.docker.com/r/redis/redis-stack) |
+[Other downloads](https://redis.io/download/#redis-stack-downloads)
+
+---
+
+## Quick start
+
+*Start a docker*
+ ```docker run redis/redis-stack:latest```
+
+*Start a docker with the custom password foo*
+ ```docker run -e REDIS_ARGS="--requirepass foo" redis/redis-stack:latest```
+
+*Start a docker with both custom redis arguments and a search configuration*
+```docker run -e REDIS_ARGS="--requirepass foo" -e REDISEARCH_ARGS="MAXSEARCHRESULTS 5" redis/redis-stack:latest```
+
+*From a locally installed package: start a redis stack with custom search results and passwords*
+
+```REDISEARCH_ARGS="MAXSEARCHRESULTS 5" redis-stack-server --requirepass foo```
+
+----
+
 ## Development Requirements
 
 * Python > 3.10 (for this toolkit) and [poetry](https://python-poetry.org)

--- a/stack/recipes/__init__.py
+++ b/stack/recipes/__init__.py
@@ -125,7 +125,7 @@ class Recipe(object):
         # so, if we have a non-master (or non fixed) release (i.e 6.2.4-v5)
         # we split accordingly, and reseed the version
         config = Config()
-        ver = config.get_key("version")[self.PACKAGE_NAME].split("-")
+        ver = config.get_key("versions")[self.PACKAGE_NAME].split("-")
         if len(ver) != 0:
             for idx, v in enumerate(fpmargs):
                 if v.find('--version') != -1:

--- a/stack/recipes/__init__.py
+++ b/stack/recipes/__init__.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import re
 
 import jinja2
 from loguru import logger
@@ -118,6 +119,21 @@ class Recipe(object):
         return fpmargs
 
     def pacman(self, fpmargs, distribution):
+        
+        # replace the version, due to an awesome - archlinux packaging bug
+        # we can't rely on the split in semver
+        # so, if we have a non-master (or non fixed) release (i.e 6.2.4-v5)
+        # we split accordingly, and reseed the version
+        config = Config()
+        ver = config.get_key("version")[self.PACKAGE_NAME].split("-")
+        if len(ver) != 0:
+            for idx, v in enumerate(fpmargs):
+                if v.find('--version') != -1:
+                    break
+            f = re.findall("[0-9]{1,3}", ver[1])
+            fpmargs[idx] = f"--version {ver}"
+            fpmargs.append(f"--iteration {f[0]}")
+        
         fpmargs.append(
             f"-p {self.C.get_key(self.PACKAGE_NAME)['product']}-{self.version}.{self.ARCH}.pkg"
         )

--- a/stack/recipes/__init__.py
+++ b/stack/recipes/__init__.py
@@ -131,7 +131,7 @@ class Recipe(object):
                 if v.find('--version') != -1:
                     break
             f = re.findall("[0-9]{1,3}", ver[1])
-            fpmargs[idx] = f"--version {ver}"
+            fpmargs[idx] = f"--version {ver[0]}"
             fpmargs.append(f"--iteration {f[0]}")
         
         fpmargs.append(


### PR DESCRIPTION
- RedisInsight 2.2.0 (#129)
- release rules changes (#128)
- removing edge, from release docker names (#132)
- redistimeseries 1.6.13 (#138)
- Update RedisBloom 2.2.17 (#141)
- Redis 7.0.2 (#142)
- Updating Redisinsight version for 2.4.0 (#144)
- Updating README with download links (#143)
- Adding the packages bucket as another release destination (#145)
- Unifying entrypoint script (#146)
- Adding helm chart to release process (#149)
- RedisTimeSeries 1.6.16 and RedisGraph 2.8.15 (#150)
- RediSearch 2.4.9 (#151)
- separating the manifests
- Arm snap image (#155)
- x86_64 AppImage Support (#154)
- nightly edge builds (#163)
- Upgrading build system to python 3.10 (#162)
- Fetch redis if built, or build (#166)
- redis 7.0.4 (#165)
- Updating RedisTimeSeries to 1.6.17 (#171)
- New RedisInsight version, and nodejs upgrade (#167)
- RediSearch 2.8.16, RedisGraph 2.4.11 (#174)
- Update RedisBloom v2.2.18 (#170)
- RedisJSON 2.2.0 (#175)
- RedisGraph 2.8.17 (#177)
- nightly credential check (#183)
- release paths for drafter (#184)
- README: highlight release process for RedisInsight
- Adding badges to README (#176)
- Green, forked PRs (#186)
- Fixing docker entrypoints for variable passing (#192)
- Ensuring armx linux, does not use jemalloc (#193)
- Adding README samples for running, and removing the double prefix on REDIS_ARGS (#194)
- Component upgrades (#196)
- adding link to latest and helm (#195)
- Labels with cleaner prefixes (#197)
- Updating the label for the helm chart.
- Quoting the paths in the entrypoint (#201)
- Upgrading FPM to 1.14.2 (#206)
- Support for archlinux packages (#205)
- Unit test to ensure versions are as set (#204)
- Consistency for dockergen arguments (#159)
- Create LICENSE (#207)
- Gathering test results (#208)
- Ensuring sha256 generating for missing packages (#209)
- New versions of modules (#211)
- Redis 7.0.5 (#220)
- marking docker as latest based on a variable (#221)
- ISLATEST is in caps, for the latest push. (#223)
