### PR TITLE
Updating the docker publish action name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,7 @@ jobs:
               redisfab/redis-stack-server:${{steps.get_version.outputs.VERSION}}-arm64
           docker manifest push redis/redis-stack-server:${{ steps.get_version.outputs.VERSION}}
 
-      - name: publish redis-stack docker
+      - name: publish redis-stack docker as latest
         if: ${{ env.ISLATEST == 'YES' }}
         run: |
           docker manifest create redis/redis-stack:latest \


### PR DESCRIPTION
This PR will be used with others for the 6.2 and 7.0 branches to fix issue #268.

We have a bad merge in those branches, meaning only dockers marked as LATEST are published to dockerhub. But in reality, we want to restore all releases going upstream.