### PR TITLE
Using the commit sha for the branch checkout on remotes

### DIFF
--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -855,7 +855,7 @@ jobs:
            -s ssh.key \
            -u ${{secrets.M1_SSH_USER}} \
            -v `echo $RANDOM` \
-           -g HEAD
+           -g ${{github.sha}}
 
 ###################### COLLATE DOCKERS ##################
  docker-push:


### PR DESCRIPTION
closes #291