### PR TITLE
GPG signing linux tarballs

### DIFF
--- a/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
+++ b/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
@@ -265,6 +265,15 @@ jobs:
            rm key
          fi
 
+      - name: gpg sign tarball
+        if: steps.iamafork.outputs.IAMAFORK == 'false'
+        run: |
+            echo allow-preset-passphrase > ~/.gnupg/gpg-agent.conf
+            gpg-connect-agent reloadagent /bye
+            /usr/lib/gnupg/gpg-preset-passphrase -P '${{ secrets.GPG_PASSWORD }}' -c --preset ${{ steps.get_gpg_keygrip.outputs.GPG_KEYGRIP }}
+            gpg --detach-sign --armor *.tar.gz
+
+
     #  - name: run tests
     #    run: |
     #      source .venv/bin/activate
@@ -291,7 +300,7 @@ jobs:
        continue-on-error: true
        run: |
          mkdir -p s3uploads
-         cp *.${{env.target}} *.tar.gz s3uploads
+         cp *.${{env.target}} *.tar.gz *.asc s3uploads
          cd s3uploads
          for i in `ls`; do
            sha256sum $i |awk '{print $1}' > $i.sha256

--- a/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
+++ b/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
@@ -265,13 +265,13 @@ jobs:
            rm key
          fi
 
-      - name: gpg sign tarball
-        if: steps.iamafork.outputs.IAMAFORK == 'false'
-        run: |
-            echo allow-preset-passphrase > ~/.gnupg/gpg-agent.conf
-            gpg-connect-agent reloadagent /bye
-            /usr/lib/gnupg/gpg-preset-passphrase -P '${{ secrets.GPG_PASSWORD }}' -c --preset ${{ steps.get_gpg_keygrip.outputs.GPG_KEYGRIP }}
-            gpg --detach-sign --armor *.tar.gz
+     - name: gpg sign tarball
+       if: steps.iamafork.outputs.IAMAFORK == 'false'
+       run: |
+           echo allow-preset-passphrase > ~/.gnupg/gpg-agent.conf
+           gpg-connect-agent reloadagent /bye
+           /usr/lib/gnupg/gpg-preset-passphrase -P '${{ secrets.GPG_PASSWORD }}' -c --preset ${{ steps.get_gpg_keygrip.outputs.GPG_KEYGRIP }}
+           gpg --detach-sign --armor *.tar.gz
 
 
     #  - name: run tests

--- a/.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+++ b/.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
@@ -286,6 +286,14 @@ jobs:
             rpmsign --addsign --key-id ${{ steps.get_gpg_id.outputs.GPG_ID}} *.rpm
             rm key
 
+      - name: gpg sign tarball
+        if: steps.iamafork.outputs.IAMAFORK == 'false'
+        run: |
+            echo allow-preset-passphrase > ~/.gnupg/gpg-agent.conf
+            gpg-connect-agent reloadagent /bye
+            /usr/lib/gnupg/gpg-preset-passphrase -P '${{ secrets.GPG_PASSWORD }}' -c --preset ${{ steps.get_gpg_keygrip.outputs.GPG_KEYGRIP }}
+            gpg --detach-sign --armor *.tar.gz
+
       - name: run tests in dockers
         run: |
           source .venv/bin/activate
@@ -338,7 +346,7 @@ jobs:
         run: |
           mkdir -p s3uploads
           if [ -z ${{env.testplatform }} ]; then
-            cp *.${{env.target}} *.tar.gz s3uploads
+            cp *.${{env.target}} *.tar.gz *.asc s3uploads
           else
             cp *.${{env.target}} s3uploads
           fi


### PR DESCRIPTION
As discussed - no need to sign the OSX zip files, since the binaries within are themselves signed with OSX tools