### PR TITLE
Fixing nightly, edge docker to pull edge binaries

### DIFF
--- a/.github/workflows/DOCKER_REUSABLE.yml
+++ b/.github/workflows/DOCKER_REUSABLE.yml
@@ -92,22 +92,14 @@ jobs:
 
       - name: Log in to DockerHub
         uses: docker/login-action@v2
-        if: steps.iamafork.outputs.IAMAFORK == 'false'
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: build and publish docker
-        if: steps.iamafork.outputs.IAMAFORK == 'false'
         run: |
           source .venv/bin/activate
           invoke dockerbuild -a ${{inputs.arch}} -d envs/dockers/Dockerfile.${{ matrix.package }} -t redisfab/${{matrix.package}}:${{steps.get_version.outputs.VERSION}}-${{inputs.arch}} -r . -b
-
-      - name: build docker
-        if: steps.iamafork.outputs.IAMAFORK == 'true'
-        run: |
-          source .venv/bin/activate
-          invoke dockerbuild -a ${{inputs.arch}} -d envs/dockers/Dockerfile.${{ matrix.package }} -t redisfab/${{matrix.package}}:${{steps.get_version.outputs.VERSION}}-${{inputs.arch}} -r .
 
       - name: test docker build
         run: |


### PR DESCRIPTION
It turns out that in certain cases of running a schedule based job, you're not in a fork.