### PR TITLE
Multi-platform docker build fix

### DIFF
--- a/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
+++ b/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
@@ -208,6 +208,9 @@ jobs:
 
      - name: set up buildx
        uses: docker/setup-buildx-action@v2
+       with:
+         install: true
+         version: 0.9.1
 
      - run: gem install fpm -v ${{env.fpmversion}}
      - name: display structure

--- a/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
+++ b/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
@@ -210,7 +210,7 @@ jobs:
        uses: docker/setup-buildx-action@v2
        with:
          install: true
-         version: 0.9.1
+         version: v0.9.1
 
      - run: gem install fpm -v ${{env.fpmversion}}
      - name: display structure

--- a/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
+++ b/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
@@ -206,6 +206,7 @@ jobs:
      - name: install qemu
        uses: docker/setup-qemu-action@v2
 
+     # https://github.com/docker/buildx/issues/1509
      - name: set up buildx
        uses: docker/setup-buildx-action@v2
        with:

--- a/.github/workflows/DOCKER_REUSABLE.yml
+++ b/.github/workflows/DOCKER_REUSABLE.yml
@@ -84,6 +84,9 @@ jobs:
 
       - uses: docker/setup-qemu-action@v2
       - uses: docker/setup-buildx-action@v2
+        with:
+          install: true
+          version: 0.9.1
 
       - name: generate docker file
         run: |

--- a/.github/workflows/DOCKER_REUSABLE.yml
+++ b/.github/workflows/DOCKER_REUSABLE.yml
@@ -102,6 +102,7 @@ jobs:
           invoke dockerbuild -a ${{inputs.arch}} -d envs/dockers/Dockerfile.${{ matrix.package }} -t redisfab/${{matrix.package}}:${{steps.get_version.outputs.VERSION}}-${{inputs.arch}} -r . -b
 
       - name: test docker build
+        if: ${{ inputs.arch != 'arm64' }}
         run: |
           source .venv/bin/activate
           invoke test-ci-dockers -d ${{matrix.package}} -a ${{inputs.arch}} -v ${{steps.get_version.outputs.VERSION}}-${{inputs.arch}}

--- a/.github/workflows/DOCKER_REUSABLE.yml
+++ b/.github/workflows/DOCKER_REUSABLE.yml
@@ -86,7 +86,7 @@ jobs:
       - uses: docker/setup-buildx-action@v2
         with:
           install: true
-          version: 0.9.1
+          version: v0.9.1
 
       - name: generate docker file
         run: |

--- a/.github/workflows/DOCKER_REUSABLE.yml
+++ b/.github/workflows/DOCKER_REUSABLE.yml
@@ -83,6 +83,8 @@ jobs:
           echo "VERSION=$realversion" >> $GITHUB_OUTPUT
 
       - uses: docker/setup-qemu-action@v2
+
+      # https://github.com/docker/buildx/issues/1509
       - uses: docker/setup-buildx-action@v2
         with:
           install: true

--- a/.github/workflows/nightly-edge-docker.yml
+++ b/.github/workflows/nightly-edge-docker.yml
@@ -104,7 +104,7 @@ jobs:
 
  docker-push:
    needs: [x86_64-docker, arm64-docker]
-   name: Push ${{matrix.package}} manifest
+   name: Push ${{matrix.package}}
    strategy:
      matrix:
        package: ['redis-stack-server', 'redis-stack']
@@ -127,16 +127,13 @@ jobs:
 
      - name: pull, retag, push arm64
        run: |
-         docker pull redisfab/${{matrix.package}}:${{env.version}}-arm64
+         docker pull redisfab/${{matrix.package}}:${{env.version}}-arm64 --platform arm64
          docker tag redisfab/${{matrix.package}}:${{env.version}}-arm64 redis/${{matrix.package}}:${{env.version}}-arm64
          docker push redis/${{matrix.package}}:${{env.version}}-arm64
 
-     - name: create the manifest
+     - name: create and push the manifest
        run: |
          docker manifest create redis/${{ matrix.package }}:${{ env.version }} \
            redis/${{ matrix.package }}:${{ env.version }}-x86_64 \
            redis/${{ matrix.package }}:${{ env.version }}-arm64
-
-     - name: push the manifest
-       run: |
          docker manifest push redis/${{matrix.package}}:${{ env.version }}

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -18,22 +18,22 @@ on:
 jobs:
 
 ###################### ARM JOBS #########################
-# arm64-bionic:
-#   uses: ./.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
-#   with:
-#     image_name: ubuntu:bionic
-#     platform: bionic
-#     osname: Linux
-#     osnick: ubuntu18.04
-#     arch: arm64
-#     target: deb
-#     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip
-#     pythonversion: "3.10"
-#   secrets:
-#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#     GPG_KEY: ${{ secrets.GPG_KEY }}
-#     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+ arm64-bionic:
+   uses: ./.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
+   with:
+     image_name: ubuntu:bionic
+     platform: bionic
+     osname: Linux
+     osnick: ubuntu18.04
+     arch: arm64
+     target: deb
+     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip
+     pythonversion: "3.10"
+   secrets:
+     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+     GPG_KEY: ${{ secrets.GPG_KEY }}
+     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
 
  arm64-focal:
@@ -53,22 +53,22 @@ jobs:
      GPG_KEY: ${{ secrets.GPG_KEY }}
      GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
-# arm64-jammy:
-#   uses: ./.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
-#   with:
-#     image_name: ubuntu:jammy
-#     platform: jammy
-#     osname: Linux
-#     osnick: ubuntu22.04
-#     arch: arm64
-#     target: deb
-#     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip
-#     pythonversion: "3.10"
-#   secrets:
-#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#     GPG_KEY: ${{ secrets.GPG_KEY }}
-#     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+ arm64-jammy:
+   uses: ./.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
+   with:
+     image_name: ubuntu:jammy
+     platform: jammy
+     osname: Linux
+     osnick: ubuntu22.04
+     arch: arm64
+     target: deb
+     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip
+     pythonversion: "3.10"
+   secrets:
+     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+     GPG_KEY: ${{ secrets.GPG_KEY }}
+     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
  arm64-focal-redisinsight-web:
    uses: ./.github/workflows/REDISINSIGHT_WEB_REUSABLE.yml
@@ -96,17 +96,17 @@ jobs:
      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_REDISFAB_USERNAME }}
      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_REDISFAB_TOKEN }}
 
-# arm64-snap:
-#   uses: ./.github/workflows/SNAP_REUSABLE.yml
-#   needs: [arm64-bionic]
-#   with:
-#     arch: arm64
-#     platform: bionic
-#     osnick: ubuntu18.04
-#     pythonversion: "3.10"
-#   secrets:
-#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+ arm64-snap:
+   uses: ./.github/workflows/SNAP_REUSABLE.yml
+   needs: [arm64-bionic]
+   with:
+     arch: arm64
+     platform: bionic
+     osnick: ubuntu18.04
+     pythonversion: "3.10"
+   secrets:
+     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 
 # ##################### x86_64 JOBS #########################
@@ -141,22 +141,22 @@ jobs:
      GPG_KEY: ${{ secrets.GPG_KEY }}
      GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
-# x86_64-jammy:
-#   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
-#   with:
-#     image_name: ubuntu:jammy
-#     platform: jammy
-#     osname: Linux
-#     osnick: ubuntu22.04
-#     arch: x86_64
-#     target: deb
-#     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
-#     pythonversion: "3.10"
-#   secrets:
-#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#     GPG_KEY: ${{ secrets.GPG_KEY }}
-#     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+ x86_64-jammy:
+   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+   with:
+     image_name: ubuntu:jammy
+     platform: jammy
+     osname: Linux
+     osnick: ubuntu22.04
+     arch: x86_64
+     target: deb
+     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
+     pythonversion: "3.10"
+   secrets:
+     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+     GPG_KEY: ${{ secrets.GPG_KEY }}
+     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
  x86_64-docker:
    uses: ./.github/workflows/DOCKER_REUSABLE.yml
@@ -169,724 +169,724 @@ jobs:
      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_REDISFAB_USERNAME }}
      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_REDISFAB_TOKEN }}
 
-# x86_64-snap:
-#   uses: ./.github/workflows/SNAP_REUSABLE.yml
-#   needs: [x86_64-focal]
+ x86_64-snap:
+   uses: ./.github/workflows/SNAP_REUSABLE.yml
+   needs: [x86_64-focal]
+   with:
+     arch: x86_64
+     platform: focal
+     osnick: ubuntu20.04
+     pythonversion: "3.10"
+   secrets:
+     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+ x86_64-appimage:
+   uses: ./.github/workflows/APPIMAGE_REUSABLE.yml
+   needs: [x86_64-bionic]
+   with:
+     arch: x86_64
+     platform: bionic
+     osnick: ubuntu18.04
+     pythonversion: "3.10"
+   secrets:
+     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+ x86_64-bionic:
+   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+   with:
+     image_name: ubuntu:bionic
+     platform: bionic
+     osname: Linux
+     osnick: ubuntu18.04
+     arch: x86_64
+     target: deb
+     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
+     pythonversion: "3.10"
+   secrets:
+     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+     GPG_KEY: ${{ secrets.GPG_KEY }}
+     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+
+ x86_64-xenial:
+   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+   with:
+     image_name: ubuntu:xenial
+     platform: xenial
+     osname: Linux
+     osnick: ubuntu16.04
+     arch: x86_64
+     target: deb
+     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
+     pythonversion: "3.10"
+   secrets:
+     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+     GPG_KEY: ${{ secrets.GPG_KEY }}
+     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+
+#  # uses precompiled ubuntu binaries, hence the testplatform override
+# x86_64-archlinux:
+#   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
 #   with:
-#     arch: x86_64
+#     image_name: archlinux:latest
 #     platform: focal
+#     testplatform: archlinux
 #     osnick: ubuntu20.04
-#     pythonversion: "3.10"
-#   secrets:
-#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#
-# x86_64-appimage:
-#   uses: ./.github/workflows/APPIMAGE_REUSABLE.yml
-#   needs: [x86_64-bionic]
-#   with:
 #     arch: x86_64
-#     platform: bionic
-#     osnick: ubuntu18.04
-#     pythonversion: "3.10"
-#   secrets:
-#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#
-# x86_64-bionic:
-#   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
-#   with:
-#     image_name: ubuntu:bionic
-#     platform: bionic
 #     osname: Linux
-#     osnick: ubuntu18.04
-#     arch: x86_64
-#     target: deb
-#     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
+#     target: pkg
+#     build_deps: pacman -Syyu --noconfirm gcc gcc-libs git openssl jq wget python python-pip openssh make
 #     pythonversion: "3.10"
 #   secrets:
 #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
 #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 #     GPG_KEY: ${{ secrets.GPG_KEY }}
 #     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+
+ bullseye:
+   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+   with:
+     image_name: debian:bullseye-slim
+     platform: bullseye
+     osname: Linux
+     osnick: bullseye
+     arch: x86_64
+     target: deb
+     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
+     pythonversion: "3.10"
+   secrets:
+     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+     GPG_KEY: ${{ secrets.GPG_KEY }}
+     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+
+ x86_64-rhel7:
+   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+   with:
+     image_name: centos:7
+     platform: rhel7
+     osname: Linux
+     osnick: rhel7
+     arch: x86_64
+     target: rpm
+     build_deps: |
+      yum install -y epel-release
+      yum install -y gcc make jemalloc-devel openssl-devel python3 python3-pip jq wget
+     pythonversion: "3.10"
+   secrets:
+     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+     GPG_KEY: ${{ secrets.GPG_KEY }}
+     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+
+ x86_64_amazonlinux2:
+  name: Amazonlinux2 (x86_64)
+  runs-on: ubuntu-latest
+  needs: [ x86_64-rhel7 ]
+  strategy:
+    matrix:
+      package: ['redis-stack-server']  # add the matrix back if multiple packages are a thing again
+  env:
+    arch: x86_64
+    platform: rhel7
+    testplatform: amazonlinux2
+    osnick: rhel7
+    osname: Linux
+    target: rpm
+    pythonversion: "3.10"
+  steps:
+
+   - name: checkout sources
+     uses: actions/checkout@v3
+   - name: Cache dependencies
+     uses: actions/cache@v3
+     with:
+       path: |
+         /var/cache/apt/archives/**.deb
+         /var/cache/yum
+         ~/.cache/pip
+         ~/.cache/pypoetry
+         ~/.local/share/gem
+       key: pypoetry-${{hashFiles('pyproject.toml', '.github/workflows/*.yml')}}-${{env.platform}}-${{env.arch}}-package
+   - name: install python
+     uses: actions/setup-python@v4
+     with:
+       python-version: "${{env.pythonversion}}"
+   - name: install poetry
+     uses: snok/install-poetry@v1
+     with:
+       version: latest
+       virtualenvs-in-project: true
+       virtualenvs-create: true
+       installer-parallel: true
+
+   - name: install packaging and testing tools
+     run: |
+       poetry install
+
+   - uses: actions/download-artifact@v3
+     with:
+       name: redis-stack-server-${{env.platform}}-${{env.arch}}.${{env.target}}
+
+   - uses: actions/download-artifact@v3
+     with:
+       name: redis-stack-server-${{env.platform}}-${{env.arch}}.tar.gz
+
+   - name: run tests in dockers
+     run: |
+       source .venv/bin/activate
+       mkdir redis-stack
+       cp *.tar.gz redis-stack/${{ matrix.package }}.tar.gz
+       cp *.${{ env.target }} redis-stack/${{ matrix.package }}.${{ env.target }}
+       pytest -m "${{env.testplatform}} and not physical and not arm" --junit-xml=results.xml
+
+   - uses: dorny/test-reporter@v1
+     if: success() || failure()
+     with:
+       name: Test Results ${{env.testplatform}} ${{env.osnick}} ${{env.arch}}
+       path: '*.xml'
+       reporter: java-junit
+       list-suites: all
+       list-tests: all
+       max-annotations: 10
+
+ x86-64_rhel8:
+   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+   with:
+     image_name: oraclelinux:8
+     platform: rhel8
+     osname: Linux
+     osnick: rhel8
+     arch: x86_64
+     target: rpm
+     pythonversion: "3.10"
+     build_deps: |
+       dnf install -y oracle-epel-release-el8
+       dnf install -y gcc make jemalloc-devel openssl-devel tar git python3 python3-pip jq wget
+   secrets:
+     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+     GPG_KEY: ${{ secrets.GPG_KEY }}
+     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+
+##################### OSX JOBS #########################
+
+# osx is the only one of these that is really
+ build-package-osx:
+
+   name: Mac (x86_64) Build
+   env:
+     arch: x86_64
+     osnick: catalina
+     target: zip
+     platform: catalina
+     osname: macos
+     pythonversion: "3.10"
+     fpmversion: 1.14.2
+     rubyversion: 2.7.2
+
+   runs-on: macos-latest
+
+   steps:
+   - name: determine if in fork
+     id: iamafork
+     run: |
+       amfork=`jq '.pull_request.head.repo.fork' $GITHUB_EVENT_PATH`
+       echo "am I fork: ${amfork}"
+       echo "IAMAFORK=$amfork" >> $GITHUB_OUTPUT
+
+   - name: checkout sources
+     uses: actions/checkout@v3
+     with:
+       path: redis-stack
+
+   - name: get versions from config file
+     id: get_config_versions
+     run: |
+       echo PACKAGEDREDISVERSION=`grep -w "packagedredisversion" redis-stack/config.yml | cut -d ":" -f 2-2|tr -d ' '` >> $GITHUB_OUTPUT
+       echo REDISVERSION=`grep -w "redis:" redis-stack/config.yml | cut -d ":" -f 2-2|tr -d ' '` >> $GITHUB_OUTPUT
+
+   - name: check if already built
+     id: redis-already-built
+     continue-on-error: true
+     run: |
+       wget -q https://redismodules.s3.amazonaws.com/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz
+
+   - uses: ruby/setup-ruby@v1
+     with:
+       ruby-version: ${{env.rubyversion}}
+   - name: install python
+     uses: actions/setup-python@v4
+     with:
+       python-version: "${{ env.pythonversion }}"
+   - name: install poetry
+     uses: snok/install-poetry@v1
+     with:
+       version: latest
+       virtualenvs-in-project: true
+       virtualenvs-create: true
+       installer-parallel: true
+
+   - name: clone redis
+     if: steps.redis-already-built.outcome != 'success'
+     uses: actions/checkout@v3
+     with:
+       repository: redis/redis
+       path: redis
+       ref: ${{steps.get_config_versions.outputs.REDISVERSION}}
+
+   - name: install dependencies
+     run: |
+       brew install openssl@3
+       gem install fpm -v ${{env.fpmversion}}
+       cd redis-stack
+       poetry install
+   - name: build redis from source
+     if: steps.redis-already-built.outcome != 'success'
+     run: |
+       cd redis
+       make all BUILD_TLS=yes FINAL_LIBS="-lm -ldl ../deps/hiredis/libhiredis_ssl.a /usr/local/opt/openssl/lib/libssl.a /usr/local/opt/openssl/lib/libcrypto.a"
+
+   - name: package redis for s3
+     if: steps.redis-already-built.outcome != 'success'
+     run: |
+       mkdir redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}
+       cp redis/src/redis-server \
+           redis/src/redis-sentinel \
+           redis/src/redis-check-aof \
+           redis/src/redis-check-rdb \
+           redis/src/redis-benchmark \
+           redis/src/redis-cli \
+           redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}
+       tar -czvf redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz \
+           redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}
+
+   - uses: s3-actions/s3cmd@v1.2.0
+     with:
+       provider: aws
+       region: us-east-1
+       access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+       secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+   - name: persist redis to s3
+     if: steps.redis-already-built.outcome != 'success' && steps.iamafork.outputs.IAMAFORK == 'false'
+     run: |
+       s3cmd put -P redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz \
+       s3://redismodules/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz
+
+   - name: perist redis
+     if: steps.redis-already-built.outcome != 'success'
+     uses: actions/upload-artifact@v3
+     with:
+       name: redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-osx
+       path: |
+         redis/src/redis-server
+         redis/src/redis-sentinel
+         redis/src/redis-check-aof
+         redis/src/redis-check-rdb
+         redis/src/redis-benchmark
+         redis/src/redis-cli
+
+   - name: collect dependencies prior to zipping
+     run: |
+       cd redis-stack
+       source .venv/bin/activate
+       invoke package -o ${{env.osname}} -s ${{env.osnick}} -d ${{env.platform}} -a ${{env.arch}} -t zip -p redis-stack-server -k package
+
+   - name: codesign all binaries
+     if: steps.iamafork.outputs.IAMAFORK == 'false'
+     run: |
+       cd redis-stack
+       echo ${{secrets.MACOS_CERTIFICATE}} | base64 --decode > certificate.p12
+       security create-keychain -p ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
+       security default-keychain -s build.keychain
+       security unlock-keychain -p ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
+       security import certificate.p12 -k build.keychain -P ${{ secrets.MACOS_CERTIFICATE_PASSWORD }} -T /usr/bin/codesign
+       security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
+       CODESIGN_IDENTITY=`security find-identity -v|head -n 1|awk '{print $2}'`
+       for i in `ls build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/bin`; do
+         /usr/bin/codesign --options=runtime --timestamp -v --sign ${CODESIGN_IDENTITY} --entitlements etc/entitlements -f build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/bin/$i
+       done
+       for i in `ls build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/lib`; do
+         /usr/bin/codesign --options=runtime --timestamp -v --sign ${CODESIGN_IDENTITY} --entitlements etc/entitlements -f build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/lib/$i
+       done
+
+   - name: build the redis-stack-server zipfile (for homebrew)
+     run: |
+       cd redis-stack
+       source .venv/bin/activate
+       invoke package -o ${{env.osname}} -s ${{env.osnick}} -d ${{env.platform}} -a ${{env.arch}} -r ../redis/src -t zip -p redis-stack-server -k fetch
+
+   - name: perist the zipfile
+     uses: actions/upload-artifact@v3
+     with:
+       name: redis-stack-${{env.platform}}-${{env.arch}}.${{env.target}}
+       path: |
+         redis-stack/redis-stack-*.zip
+
+   - name: create the zip for notarization
+     run: |
+       cd redis-stack/build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack
+       zip -r notarized-${{env.platform}}-${{env.arch}}.zip bin lib
+
+   - name: notarize the custom zip
+     if: steps.iamafork.outputs.IAMAFORK == 'false'
+     run: |
+       cd redis-stack/build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack
+       sh ../../../../notarize.sh notarized-${{env.platform}}-${{env.arch}}.zip com.redis.redis-stack-server ${{ secrets.MAC_NOTARIZE_USERNAME }} ${{ secrets.MAC_NOTARIZE_PASSWORD }}
+
+ test-osx-intel:
+   name: Mac (x86_64) Tests
+   needs: ['build-package-osx']
+   runs-on: macos-latest
+   env:
+     arch: x86_64
+     osnick: catalina
+     target: zip
+     platform: catalina
+     osname: macos
+     pythonversion: "3.10"
+
+   steps:
+   - name: determine if in fork
+     id: iamafork
+     run: |
+       amfork=`jq '.pull_request.head.repo.fork' $GITHUB_EVENT_PATH`
+       echo "am I fork: ${amfork}"
+       echo "IAMAFORK=$amfork" >> $GITHUB_OUTPUT
+
+   - name: install python
+     uses: actions/setup-python@v4
+     with:
+       python-version: "${{ env.pythonversion }}"
+   - name: install poetry
+     uses: snok/install-poetry@v1
+     with:
+       version: latest
+       virtualenvs-in-project: true
+       virtualenvs-create: true
+       installer-parallel: true
+   - name: checkout sources
+     uses: actions/checkout@v3
+   - name: install dependencies
+     run: |
+       brew install libomp openssl coreutils
+       poetry install
+   - name: gather artifacts
+     uses: actions/download-artifact@v3
+     with:
+       path: redis-stack
+       name: redis-stack-${{env.platform}}-${{env.arch}}.${{env.target}}
+   - name: unzip the zipfile
+     run: |
+       ls -R
+       mkdir -p redis-stack
+       unzip redis-stack/redis-stack*.${{env.target}} -d redis-stack/redis-stack-server
+
+   - name: run osx tests
+     run: |
+       .venv/bin/pytest -m macos --junit-xml=results.xml
+   - uses: dorny/test-reporter@v1
+     if: success() || failure()
+     with:
+       name: Test Results ${{env.platform}} ${{env.osnick}} ${{env.arch}}
+       path: '*.xml'
+       reporter: java-junit
+       list-suites: all
+       list-tests: all
+       max-annotations: 10
+
+   - name: get package version
+     id: get_version
+     run: |
+       poetry install
+       source .venv/bin/activate
+       realversion=`invoke version`
+       echo "VERSION=$realversion" >> $GITHUB_OUTPUT
+
+   - uses: s3-actions/s3cmd@v1.2.0
+     if: steps.iamafork.outputs.IAMAFORK == 'false'
+     with:
+       provider: aws
+       region: us-east-1
+       access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+       secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+   - name: persist redis to s3
+     if: steps.iamafork.outputs.IAMAFORK == 'false'
+     run: |
+      mkdir s3dist
+      cp redis-stack/redis-stack*.${{env.target}} s3dist
+      for i in `ls s3dist`; do
+        sha256sum s3dist/$i | awk '{print $1}' > s3dist/$i.sha256
+      done
+      s3cmd put -P s3dist/* s3://redismodules/redis-stack/snapshots/
+
+ # the m1 requires a zip file so that homebrew can unpack it
+ build-package-osx-m1:
+   name: Mac (M1) Package
+   env:
+     arch: arm64
+     osnick: monterey
+     target: zip
+     platform: monterey
+     osname: macos
+     pythonversion: "3.10"
+     fpmversion: 1.14.2
+     rubyversion: 2.7.2
+   runs-on: macos-latest
+   steps:
+   - name: checkout sources
+     uses: actions/checkout@v3
+   - uses: ruby/setup-ruby@v1
+     with:
+       ruby-version: ${{env.rubyversion}}
+   - name: install python
+     uses: actions/setup-python@v4
+     with:
+       python-version: "${{ env.pythonversion }}"
+   - name: install dependencies
+     run: |
+       brew install coreutils
+   - name: install poetry
+     uses: snok/install-poetry@v1
+     with:
+       version: latest
+       virtualenvs-in-project: true
+       virtualenvs-create: true
+       installer-parallel: true
+   - name: Cache dependencies
+     uses: actions/cache@v3
+     with:
+       path: |
+         /var/cache/apt/archives/**.deb
+         ~/.cache/pip
+         ~/.cache/pypoetry
+         ~/.local/share/gem
+       key: pypoetry-${{hashFiles('**/pyproject.toml')}}-${{env.platform}}-${{env.arch}}-package
+   - name: install packaging tools
+     run: |
+       gem install fpm -v ${{env.fpmversion}}
+       poetry install
+
+   - name: determine if in fork
+     id: iamafork
+     run: |
+       amfork=`jq '.pull_request.head.repo.fork' $GITHUB_EVENT_PATH`
+       echo "am I fork: ${amfork}"
+       echo "IAMAFORK=$amfork" >> $GITHUB_OUTPUT
+
+   - name: write the ssh key to a file
+     if: steps.iamafork.outputs.IAMAFORK == 'false'
+     run: |
+       echo "${{secrets.OPERETO_KEY}}" > ssh.key
+       chmod 0400 ssh.key
+
+   - name: get versions from config file
+     id: get_config_versions
+     run: |
+       echo PACKAGEDREDISVERSION=`grep -w "packagedredisversion" config.yml | cut -d ":" -f 2-2|tr -d ' '` >> $GITHUB_OUTPUT
+       echo REDISVERSION=`grep -w "redis:" config.yml | cut -d ":" -f 2-2|tr -d ' '` >> $GITHUB_OUTPUT
+
+   - name: check if already built
+     id: redis-already-built
+     continue-on-error: true
+     run: |
+       wget -q https://redismodules.s3.amazonaws.com/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz
+
+   - name: build redis from source
+     if: steps.redis-already-built.outcome != 'success' && steps.iamafork.outputs.IAMAFORK == 'false'
+     run: |
+       source .venv/bin/activate
+       invoke build-m1-over-ssh \
+        -i ${{ secrets.M1_IP }} \
+        -u ${{ secrets.M1_SSH_USER }} \
+        -s ssh.key \
+        -v ${{ steps.get_config_versions.outputs.REDISVERSION }} \
+        -p ${{ steps.get_config_versions.outputs.PACKAGEDREDISVERSION }}
+
+   - name: package redis for s3
+     if: steps.redis-already-built.outcome != 'success'
+     run: |
+       tar -czvf redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz \
+           redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}
+   - uses: s3-actions/s3cmd@v1.2.0
+     with:
+       provider: aws
+       region: us-east-1
+       access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+       secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+   - name: persist redis to s3
+     if: steps.redis-already-built.outcome != 'success' && steps.iamafork.outputs.IAMAFORK == 'false'
+     run: |
+       s3cmd put -P redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz \
+       s3://redismodules/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz
+
+   - name: perist redis
+     if: steps.redis-already-built.outcome != 'success'
+     uses: actions/upload-artifact@v3
+     with:
+       name: redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.arch}}-osx
+       path: |
+         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-server
+         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-sentinel
+         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-check-aof
+         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-check-rdb
+         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-benchmark
+         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-cli
+
+### Once https://github.com/actions/runner/issues/805 is resolved we can do this ###
+### For now, this is how it is manually built, on the platform ###
+#    - name: build redis from source
+#      run: |
+#        cd redis
+#        make all BUILD_TLS=yes FINAL_LIBS="-lm -ldl ../deps/hiredis/libhiredis_ssl.a /opt/homebrew/opt/openssl/lib/libssl.a /opt/homebrew/opt/openssl/lib/libcrypto.a" CFLAGS="-I /opt/homebrew/opt/openssl@3/include"
 #
-# x86_64-xenial:
-#   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
-#   with:
-#     image_name: ubuntu:xenial
-#     platform: xenial
-#     osname: Linux
-#     osnick: ubuntu16.04
-#     arch: x86_64
-#     target: deb
-#     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
-#     pythonversion: "3.10"
-#   secrets:
-#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#     GPG_KEY: ${{ secrets.GPG_KEY }}
-#     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-#
-##  # uses precompiled ubuntu binaries, hence the testplatform override
-## x86_64-archlinux:
-##   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
-##   with:
-##     image_name: archlinux:latest
-##     platform: focal
-##     testplatform: archlinux
-##     osnick: ubuntu20.04
-##     arch: x86_64
-##     osname: Linux
-##     target: pkg
-##     build_deps: pacman -Syyu --noconfirm gcc gcc-libs git openssl jq wget python python-pip openssh make
-##     pythonversion: "3.10"
-##   secrets:
-##     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-##     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-##     GPG_KEY: ${{ secrets.GPG_KEY }}
-##     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-#
-# bullseye:
-#   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
-#   with:
-#     image_name: debian:bullseye-slim
-#     platform: bullseye
-#     osname: Linux
-#     osnick: bullseye
-#     arch: x86_64
-#     target: deb
-#     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
-#     pythonversion: "3.10"
-#   secrets:
-#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#     GPG_KEY: ${{ secrets.GPG_KEY }}
-#     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-#
-# x86_64-rhel7:
-#   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
-#   with:
-#     image_name: centos:7
-#     platform: rhel7
-#     osname: Linux
-#     osnick: rhel7
-#     arch: x86_64
-#     target: rpm
-#     build_deps: |
-#      yum install -y epel-release
-#      yum install -y gcc make jemalloc-devel openssl-devel python3 python3-pip jq wget
-#     pythonversion: "3.10"
-#   secrets:
-#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#     GPG_KEY: ${{ secrets.GPG_KEY }}
-#     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-#
-# x86_64_amazonlinux2:
-#  name: Amazonlinux2 (x86_64)
-#  runs-on: ubuntu-latest
-#  needs: [ x86_64-rhel7 ]
-#  strategy:
-#    matrix:
-#      package: ['redis-stack-server']  # add the matrix back if multiple packages are a thing again
-#  env:
-#    arch: x86_64
-#    platform: rhel7
-#    testplatform: amazonlinux2
-#    osnick: rhel7
-#    osname: Linux
-#    target: rpm
-#    pythonversion: "3.10"
-#  steps:
-#
-#   - name: checkout sources
-#     uses: actions/checkout@v3
-#   - name: Cache dependencies
-#     uses: actions/cache@v3
-#     with:
-#       path: |
-#         /var/cache/apt/archives/**.deb
-#         /var/cache/yum
-#         ~/.cache/pip
-#         ~/.cache/pypoetry
-#         ~/.local/share/gem
-#       key: pypoetry-${{hashFiles('pyproject.toml', '.github/workflows/*.yml')}}-${{env.platform}}-${{env.arch}}-package
-#   - name: install python
-#     uses: actions/setup-python@v4
-#     with:
-#       python-version: "${{env.pythonversion}}"
-#   - name: install poetry
-#     uses: snok/install-poetry@v1
-#     with:
-#       version: latest
-#       virtualenvs-in-project: true
-#       virtualenvs-create: true
-#       installer-parallel: true
-#
-#   - name: install packaging and testing tools
-#     run: |
-#       poetry install
-#
-#   - uses: actions/download-artifact@v3
-#     with:
-#       name: redis-stack-server-${{env.platform}}-${{env.arch}}.${{env.target}}
-#
-#   - uses: actions/download-artifact@v3
-#     with:
-#       name: redis-stack-server-${{env.platform}}-${{env.arch}}.tar.gz
-#
-#   - name: run tests in dockers
-#     run: |
-#       source .venv/bin/activate
-#       mkdir redis-stack
-#       cp *.tar.gz redis-stack/${{ matrix.package }}.tar.gz
-#       cp *.${{ env.target }} redis-stack/${{ matrix.package }}.${{ env.target }}
-#       pytest -m "${{env.testplatform}} and not physical and not arm" --junit-xml=results.xml
-#
-#   - uses: dorny/test-reporter@v1
-#     if: success() || failure()
-#     with:
-#       name: Test Results ${{env.testplatform}} ${{env.osnick}} ${{env.arch}}
-#       path: '*.xml'
-#       reporter: java-junit
-#       list-suites: all
-#       list-tests: all
-#       max-annotations: 10
-#
-# x86-64_rhel8:
-#   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
-#   with:
-#     image_name: oraclelinux:8
-#     platform: rhel8
-#     osname: Linux
-#     osnick: rhel8
-#     arch: x86_64
-#     target: rpm
-#     pythonversion: "3.10"
-#     build_deps: |
-#       dnf install -y oracle-epel-release-el8
-#       dnf install -y gcc make jemalloc-devel openssl-devel tar git python3 python3-pip jq wget
-#   secrets:
-#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#     GPG_KEY: ${{ secrets.GPG_KEY }}
-#     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-#
-###################### OSX JOBS #########################
-#
-## osx is the only one of these that is really
-# build-package-osx:
-#
-#   name: Mac (x86_64) Build
-#   env:
-#     arch: x86_64
-#     osnick: catalina
-#     target: zip
-#     platform: catalina
-#     osname: macos
-#     pythonversion: "3.10"
-#     fpmversion: 1.14.2
-#     rubyversion: 2.7.2
-#
-#   runs-on: macos-latest
-#
-#   steps:
-#   - name: determine if in fork
-#     id: iamafork
-#     run: |
-#       amfork=`jq '.pull_request.head.repo.fork' $GITHUB_EVENT_PATH`
-#       echo "am I fork: ${amfork}"
-#       echo "IAMAFORK=$amfork" >> $GITHUB_OUTPUT
-#
-#   - name: checkout sources
-#     uses: actions/checkout@v3
-#     with:
-#       path: redis-stack
-#
-#   - name: get versions from config file
-#     id: get_config_versions
-#     run: |
-#       echo PACKAGEDREDISVERSION=`grep -w "packagedredisversion" redis-stack/config.yml | cut -d ":" -f 2-2|tr -d ' '` >> $GITHUB_OUTPUT
-#       echo REDISVERSION=`grep -w "redis:" redis-stack/config.yml | cut -d ":" -f 2-2|tr -d ' '` >> $GITHUB_OUTPUT
-#
-#   - name: check if already built
-#     id: redis-already-built
-#     continue-on-error: true
-#     run: |
-#       wget -q https://redismodules.s3.amazonaws.com/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz
-#
-#   - uses: ruby/setup-ruby@v1
-#     with:
-#       ruby-version: ${{env.rubyversion}}
-#   - name: install python
-#     uses: actions/setup-python@v4
-#     with:
-#       python-version: "${{ env.pythonversion }}"
-#   - name: install poetry
-#     uses: snok/install-poetry@v1
-#     with:
-#       version: latest
-#       virtualenvs-in-project: true
-#       virtualenvs-create: true
-#       installer-parallel: true
-#
-#   - name: clone redis
-#     if: steps.redis-already-built.outcome != 'success'
-#     uses: actions/checkout@v3
-#     with:
-#       repository: redis/redis
-#       path: redis
-#       ref: ${{steps.get_config_versions.outputs.REDISVERSION}}
-#
-#   - name: install dependencies
-#     run: |
-#       brew install openssl@3
-#       gem install fpm -v ${{env.fpmversion}}
-#       cd redis-stack
-#       poetry install
-#   - name: build redis from source
-#     if: steps.redis-already-built.outcome != 'success'
-#     run: |
-#       cd redis
-#       make all BUILD_TLS=yes FINAL_LIBS="-lm -ldl ../deps/hiredis/libhiredis_ssl.a /usr/local/opt/openssl/lib/libssl.a /usr/local/opt/openssl/lib/libcrypto.a"
-#
-#   - name: package redis for s3
-#     if: steps.redis-already-built.outcome != 'success'
-#     run: |
-#       mkdir redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}
-#       cp redis/src/redis-server \
-#           redis/src/redis-sentinel \
-#           redis/src/redis-check-aof \
-#           redis/src/redis-check-rdb \
-#           redis/src/redis-benchmark \
-#           redis/src/redis-cli \
-#           redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}
-#       tar -czvf redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz \
-#           redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}
-#
-#   - uses: s3-actions/s3cmd@v1.2.0
-#     with:
-#       provider: aws
-#       region: us-east-1
-#       access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#       secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#   - name: persist redis to s3
-#     if: steps.redis-already-built.outcome != 'success' && steps.iamafork.outputs.IAMAFORK == 'false'
-#     run: |
-#       s3cmd put -P redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz \
-#       s3://redismodules/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz
-#
-#   - name: perist redis
-#     if: steps.redis-already-built.outcome != 'success'
-#     uses: actions/upload-artifact@v3
-#     with:
-#       name: redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-osx
-#       path: |
-#         redis/src/redis-server
-#         redis/src/redis-sentinel
-#         redis/src/redis-check-aof
-#         redis/src/redis-check-rdb
-#         redis/src/redis-benchmark
-#         redis/src/redis-cli
-#
-#   - name: collect dependencies prior to zipping
-#     run: |
-#       cd redis-stack
-#       source .venv/bin/activate
-#       invoke package -o ${{env.osname}} -s ${{env.osnick}} -d ${{env.platform}} -a ${{env.arch}} -t zip -p redis-stack-server -k package
-#
-#   - name: codesign all binaries
-#     if: steps.iamafork.outputs.IAMAFORK == 'false'
-#     run: |
-#       cd redis-stack
-#       echo ${{secrets.MACOS_CERTIFICATE}} | base64 --decode > certificate.p12
-#       security create-keychain -p ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
-#       security default-keychain -s build.keychain
-#       security unlock-keychain -p ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
-#       security import certificate.p12 -k build.keychain -P ${{ secrets.MACOS_CERTIFICATE_PASSWORD }} -T /usr/bin/codesign
-#       security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
-#       CODESIGN_IDENTITY=`security find-identity -v|head -n 1|awk '{print $2}'`
-#       for i in `ls build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/bin`; do
-#         /usr/bin/codesign --options=runtime --timestamp -v --sign ${CODESIGN_IDENTITY} --entitlements etc/entitlements -f build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/bin/$i
-#       done
-#       for i in `ls build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/lib`; do
-#         /usr/bin/codesign --options=runtime --timestamp -v --sign ${CODESIGN_IDENTITY} --entitlements etc/entitlements -f build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/lib/$i
-#       done
-#
-#   - name: build the redis-stack-server zipfile (for homebrew)
-#     run: |
-#       cd redis-stack
-#       source .venv/bin/activate
-#       invoke package -o ${{env.osname}} -s ${{env.osnick}} -d ${{env.platform}} -a ${{env.arch}} -r ../redis/src -t zip -p redis-stack-server -k fetch
-#
-#   - name: perist the zipfile
-#     uses: actions/upload-artifact@v3
-#     with:
-#       name: redis-stack-${{env.platform}}-${{env.arch}}.${{env.target}}
-#       path: |
-#         redis-stack/redis-stack-*.zip
-#
-#   - name: create the zip for notarization
-#     run: |
-#       cd redis-stack/build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack
-#       zip -r notarized-${{env.platform}}-${{env.arch}}.zip bin lib
-#
-#   - name: notarize the custom zip
-#     if: steps.iamafork.outputs.IAMAFORK == 'false'
-#     run: |
-#       cd redis-stack/build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack
-#       sh ../../../../notarize.sh notarized-${{env.platform}}-${{env.arch}}.zip com.redis.redis-stack-server ${{ secrets.MAC_NOTARIZE_USERNAME }} ${{ secrets.MAC_NOTARIZE_PASSWORD }}
-#
-# test-osx-intel:
-#   name: Mac (x86_64) Tests
-#   needs: ['build-package-osx']
-#   runs-on: macos-latest
-#   env:
-#     arch: x86_64
-#     osnick: catalina
-#     target: zip
-#     platform: catalina
-#     osname: macos
-#     pythonversion: "3.10"
-#
-#   steps:
-#   - name: determine if in fork
-#     id: iamafork
-#     run: |
-#       amfork=`jq '.pull_request.head.repo.fork' $GITHUB_EVENT_PATH`
-#       echo "am I fork: ${amfork}"
-#       echo "IAMAFORK=$amfork" >> $GITHUB_OUTPUT
-#
-#   - name: install python
-#     uses: actions/setup-python@v4
-#     with:
-#       python-version: "${{ env.pythonversion }}"
-#   - name: install poetry
-#     uses: snok/install-poetry@v1
-#     with:
-#       version: latest
-#       virtualenvs-in-project: true
-#       virtualenvs-create: true
-#       installer-parallel: true
-#   - name: checkout sources
-#     uses: actions/checkout@v3
-#   - name: install dependencies
-#     run: |
-#       brew install libomp openssl coreutils
-#       poetry install
-#   - name: gather artifacts
-#     uses: actions/download-artifact@v3
-#     with:
-#       path: redis-stack
-#       name: redis-stack-${{env.platform}}-${{env.arch}}.${{env.target}}
-#   - name: unzip the zipfile
-#     run: |
-#       ls -R
-#       mkdir -p redis-stack
-#       unzip redis-stack/redis-stack*.${{env.target}} -d redis-stack/redis-stack-server
-#
-#   - name: run osx tests
-#     run: |
-#       .venv/bin/pytest -m macos --junit-xml=results.xml
-#   - uses: dorny/test-reporter@v1
-#     if: success() || failure()
-#     with:
-#       name: Test Results ${{env.platform}} ${{env.osnick}} ${{env.arch}}
-#       path: '*.xml'
-#       reporter: java-junit
-#       list-suites: all
-#       list-tests: all
-#       max-annotations: 10
-#
-#   - name: get package version
-#     id: get_version
-#     run: |
-#       poetry install
-#       source .venv/bin/activate
-#       realversion=`invoke version`
-#       echo "VERSION=$realversion" >> $GITHUB_OUTPUT
-#
-#   - uses: s3-actions/s3cmd@v1.2.0
-#     if: steps.iamafork.outputs.IAMAFORK == 'false'
-#     with:
-#       provider: aws
-#       region: us-east-1
-#       access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#       secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#
-#   - name: persist redis to s3
-#     if: steps.iamafork.outputs.IAMAFORK == 'false'
-#     run: |
-#      mkdir s3dist
-#      cp redis-stack/redis-stack*.${{env.target}} s3dist
-#      for i in `ls s3dist`; do
-#        sha256sum s3dist/$i | awk '{print $1}' > s3dist/$i.sha256
-#      done
-#      s3cmd put -P s3dist/* s3://redismodules/redis-stack/snapshots/
-#
-# # the m1 requires a zip file so that homebrew can unpack it
-# build-package-osx-m1:
-#   name: Mac (M1) Package
-#   env:
-#     arch: arm64
-#     osnick: monterey
-#     target: zip
-#     platform: monterey
-#     osname: macos
-#     pythonversion: "3.10"
-#     fpmversion: 1.14.2
-#     rubyversion: 2.7.2
-#   runs-on: macos-latest
-#   steps:
-#   - name: checkout sources
-#     uses: actions/checkout@v3
-#   - uses: ruby/setup-ruby@v1
-#     with:
-#       ruby-version: ${{env.rubyversion}}
-#   - name: install python
-#     uses: actions/setup-python@v4
-#     with:
-#       python-version: "${{ env.pythonversion }}"
-#   - name: install dependencies
-#     run: |
-#       brew install coreutils
-#   - name: install poetry
-#     uses: snok/install-poetry@v1
-#     with:
-#       version: latest
-#       virtualenvs-in-project: true
-#       virtualenvs-create: true
-#       installer-parallel: true
-#   - name: Cache dependencies
-#     uses: actions/cache@v3
-#     with:
-#       path: |
-#         /var/cache/apt/archives/**.deb
-#         ~/.cache/pip
-#         ~/.cache/pypoetry
-#         ~/.local/share/gem
-#       key: pypoetry-${{hashFiles('**/pyproject.toml')}}-${{env.platform}}-${{env.arch}}-package
-#   - name: install packaging tools
-#     run: |
-#       gem install fpm -v ${{env.fpmversion}}
-#       poetry install
-#
-#   - name: determine if in fork
-#     id: iamafork
-#     run: |
-#       amfork=`jq '.pull_request.head.repo.fork' $GITHUB_EVENT_PATH`
-#       echo "am I fork: ${amfork}"
-#       echo "IAMAFORK=$amfork" >> $GITHUB_OUTPUT
-#
-#   - name: write the ssh key to a file
-#     if: steps.iamafork.outputs.IAMAFORK == 'false'
-#     run: |
-#       echo "${{secrets.OPERETO_KEY}}" > ssh.key
-#       chmod 0400 ssh.key
-#
-#   - name: get versions from config file
-#     id: get_config_versions
-#     run: |
-#       echo PACKAGEDREDISVERSION=`grep -w "packagedredisversion" config.yml | cut -d ":" -f 2-2|tr -d ' '` >> $GITHUB_OUTPUT
-#       echo REDISVERSION=`grep -w "redis:" config.yml | cut -d ":" -f 2-2|tr -d ' '` >> $GITHUB_OUTPUT
-#
-#   - name: check if already built
-#     id: redis-already-built
-#     continue-on-error: true
-#     run: |
-#       wget -q https://redismodules.s3.amazonaws.com/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz
-#
-#   - name: build redis from source
-#     if: steps.redis-already-built.outcome != 'success' && steps.iamafork.outputs.IAMAFORK == 'false'
-#     run: |
-#       source .venv/bin/activate
-#       invoke build-m1-over-ssh \
-#        -i ${{ secrets.M1_IP }} \
-#        -u ${{ secrets.M1_SSH_USER }} \
-#        -s ssh.key \
-#        -v ${{ steps.get_config_versions.outputs.REDISVERSION }} \
-#        -p ${{ steps.get_config_versions.outputs.PACKAGEDREDISVERSION }}
-#
-#   - name: package redis for s3
-#     if: steps.redis-already-built.outcome != 'success'
-#     run: |
-#       tar -czvf redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz \
-#           redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}
-#   - uses: s3-actions/s3cmd@v1.2.0
-#     with:
-#       provider: aws
-#       region: us-east-1
-#       access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#       secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#
-#   - name: persist redis to s3
-#     if: steps.redis-already-built.outcome != 'success' && steps.iamafork.outputs.IAMAFORK == 'false'
-#     run: |
-#       s3cmd put -P redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz \
-#       s3://redismodules/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz
-#
-#   - name: perist redis
-#     if: steps.redis-already-built.outcome != 'success'
-#     uses: actions/upload-artifact@v3
-#     with:
-#       name: redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.arch}}-osx
-#       path: |
-#         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-server
-#         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-sentinel
-#         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-check-aof
-#         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-check-rdb
-#         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-benchmark
-#         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-cli
-#
-#### Once https://github.com/actions/runner/issues/805 is resolved we can do this ###
-#### For now, this is how it is manually built, on the platform ###
-##    - name: build redis from source
-##      run: |
-##        cd redis
-##        make all BUILD_TLS=yes FINAL_LIBS="-lm -ldl ../deps/hiredis/libhiredis_ssl.a /opt/homebrew/opt/openssl/lib/libssl.a /opt/homebrew/opt/openssl/lib/libcrypto.a" CFLAGS="-I /opt/homebrew/opt/openssl@3/include"
-##
-#   - name: collect dependencies prior to packaging
-#     run: |
-#       source .venv/bin/activate
-#       invoke package -o ${{env.osname}} -s ${{env.osnick}} -d ${{env.platform}} -a ${{env.arch}} -t ${{env.target}} -p redis-stack-server -k package
-#
-#   - name: codesign all binaries
-#     if: steps.iamafork.outputs.IAMAFORK == 'false'
-#     run: |
-#       echo ${{secrets.MACOS_CERTIFICATE}} | base64 --decode > certificate.p12
-#       security create-keychain -p ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
-#       security default-keychain -s build.keychain
-#       security unlock-keychain -p ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
-#       security import certificate.p12 -k build.keychain -P ${{ secrets.MACOS_CERTIFICATE_PASSWORD }} -T /usr/bin/codesign
-#       security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
-#       CODESIGN_IDENTITY=`security find-identity -v|head -n 1|awk '{print $2}'`
-#       for i in `ls build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/bin`; do
-#         /usr/bin/codesign --options=runtime --timestamp -v --sign ${CODESIGN_IDENTITY} --entitlements etc/entitlements -f build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/bin/$i
-#       done
-#       for i in `ls build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/lib`; do
-#         /usr/bin/codesign --options=runtime --timestamp -v --sign ${CODESIGN_IDENTITY} --entitlements etc/entitlements -f build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/lib/$i
-#       done
-#
-#   - name: build redis-stack-server zipfile
-#     run: |
-#       source .venv/bin/activate
-#       invoke package -o ${{env.osname}} -s ${{env.osnick}} -d ${{env.platform}} -a ${{env.arch}} -t ${{env.target}} -p redis-stack-server -k fetch
-#       for i in `ls *.zip`; do
-#         sha256sum $i |awk '{print $1}' > $i.sha256
-#       done
-#
-#   - name: persist the zipfile
-#     uses: actions/upload-artifact@v3
-#     with:
-#       name: redis-stack-server-${{env.platform}}-${{env.arch}}.${{env.target}}
-#       path: |
-#         *.zip
-#
-#   - name: create the zip for notarization
-#     run: |
-#       cd build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack
-#       zip -r notarized-${{env.platform}}-${{env.arch}}.zip bin lib
-#
-#   - name: persist the codesigned artifacts
-#     uses: actions/upload-artifact@v3
-#     with:
-#       name: codesigned-${{env.platform}}-${{env.arch}}
-#       path: |
-#         build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/*.zip
-#
-#   - name: notarize the custom zip
-#     if: steps.iamafork.outputs.IAMAFORK == 'false'
-#     run: |
-#       cd build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack
-#       sh ../../../../notarize.sh notarized-${{env.platform}}-${{env.arch}}.zip com.redis.redis-stack-server ${{ secrets.MAC_NOTARIZE_USERNAME }} ${{ secrets.MAC_NOTARIZE_PASSWORD }}
-#
-#   - uses: s3-actions/s3cmd@v1.2.0
-#     if: steps.iamafork.outputs.IAMAFORK == 'false'
-#     with:
-#       provider: aws
-#       region: us-east-1
-#       access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#       secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#   - name: upload snapshots
-#     if: steps.iamafork.outputs.IAMAFORK == 'false'
-#     run: |
-#       s3cmd put -P *.${{env.target}} s3://redismodules/redis-stack/snapshots/
-#       s3cmd put -P *.sha256 s3://redismodules/redis-stack/snapshots/
-#
-# test-osx-m1:
-#   name: Mac (M1) tests
-#   needs: [build-package-osx-m1]
-#   env:
-#     arch: arm64
-#     osnick: monterey
-#     target: zip
-#     platform: monterey
-#     osname: macos
-#     pythonversion: "3.10"
-#   runs-on: ubuntu-latest
-#   steps:
-#     - name: determine if in fork
-#       id: iamafork
-#       run: |
-#         amfork=`jq '.pull_request.head.repo.fork' $GITHUB_EVENT_PATH`
-#         echo "am I fork: ${amfork}"
-#         echo "IAMAFORK=$amfork" >> $GITHUB_OUTPUT
-#
-#     - name: checkout sources
-#       uses: actions/checkout@v3
-#     - name: Cache dependencies
-#       uses: actions/cache@v3
-#       with:
-#         path: |
-#           /var/cache/apt/archives/**.deb
-#           ~/.cache/pip
-#           ~/.cache/pypoetry
-#           ~/.local/share/gem
-#           poetry.lock
-#         key: pypoetry-${{hashFiles('**/pyproject.toml')}}-${{env.platform}}-${{env.arch}}-package
-#     - name: install python
-#       uses: actions/setup-python@v4
-#       with:
-#         python-version: "${{ env.pythonversion }}"
-#     - name: install poetry
-#       uses: snok/install-poetry@v1
-#       with:
-#         version: latest
-#         virtualenvs-in-project: true
-#         virtualenvs-create: true
-#         installer-parallel: true
-#     - name: gather artifacts
-#       uses: actions/download-artifact@v3
-#       with:
-#         name: redis-stack-server-${{env.platform}}-${{env.arch}}.${{env.target}}
-#
-#     - name: write the ssh key to a file
-#       if: steps.iamafork.outputs.IAMAFORK == 'false'
-#       run: |
-#         echo "${{secrets.OPERETO_KEY}}" > ssh.key
-#         chmod 0400 ssh.key
-#
-#     - name: get package version
-#       id: get_version
-#       run: |
-#         poetry install
-#         source .venv/bin/activate
-#         realversion=`invoke version`
-#         echo "VERSION=$realversion" >> $GITHUB_OUTPUT
-#
-#     - name: run the tests
-#       if: steps.iamafork.outputs.IAMAFORK == 'false'
-#       run: |
-#         source .venv/bin/activate
-#         invoke test-over-ssh -b \
-#           redis-stack-server-${{steps.get_version.outputs.VERSION}}.${{env.platform}}.${{env.arch}}.${{env.target}} \
-#           -i ${{secrets.M1_IP}} \
-#           -m macos \
-#           -p redis-stack-server \
-#           -s ssh.key \
-#           -u ${{secrets.M1_SSH_USER}} \
-#           -v `echo $RANDOM` \
-#           -g ${{github.head_ref}}
+   - name: collect dependencies prior to packaging
+     run: |
+       source .venv/bin/activate
+       invoke package -o ${{env.osname}} -s ${{env.osnick}} -d ${{env.platform}} -a ${{env.arch}} -t ${{env.target}} -p redis-stack-server -k package
+
+   - name: codesign all binaries
+     if: steps.iamafork.outputs.IAMAFORK == 'false'
+     run: |
+       echo ${{secrets.MACOS_CERTIFICATE}} | base64 --decode > certificate.p12
+       security create-keychain -p ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
+       security default-keychain -s build.keychain
+       security unlock-keychain -p ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
+       security import certificate.p12 -k build.keychain -P ${{ secrets.MACOS_CERTIFICATE_PASSWORD }} -T /usr/bin/codesign
+       security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
+       CODESIGN_IDENTITY=`security find-identity -v|head -n 1|awk '{print $2}'`
+       for i in `ls build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/bin`; do
+         /usr/bin/codesign --options=runtime --timestamp -v --sign ${CODESIGN_IDENTITY} --entitlements etc/entitlements -f build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/bin/$i
+       done
+       for i in `ls build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/lib`; do
+         /usr/bin/codesign --options=runtime --timestamp -v --sign ${CODESIGN_IDENTITY} --entitlements etc/entitlements -f build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/lib/$i
+       done
+
+   - name: build redis-stack-server zipfile
+     run: |
+       source .venv/bin/activate
+       invoke package -o ${{env.osname}} -s ${{env.osnick}} -d ${{env.platform}} -a ${{env.arch}} -t ${{env.target}} -p redis-stack-server -k fetch
+       for i in `ls *.zip`; do
+         sha256sum $i |awk '{print $1}' > $i.sha256
+       done
+
+   - name: persist the zipfile
+     uses: actions/upload-artifact@v3
+     with:
+       name: redis-stack-server-${{env.platform}}-${{env.arch}}.${{env.target}}
+       path: |
+         *.zip
+
+   - name: create the zip for notarization
+     run: |
+       cd build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack
+       zip -r notarized-${{env.platform}}-${{env.arch}}.zip bin lib
+
+   - name: persist the codesigned artifacts
+     uses: actions/upload-artifact@v3
+     with:
+       name: codesigned-${{env.platform}}-${{env.arch}}
+       path: |
+         build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/*.zip
+
+   - name: notarize the custom zip
+     if: steps.iamafork.outputs.IAMAFORK == 'false'
+     run: |
+       cd build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack
+       sh ../../../../notarize.sh notarized-${{env.platform}}-${{env.arch}}.zip com.redis.redis-stack-server ${{ secrets.MAC_NOTARIZE_USERNAME }} ${{ secrets.MAC_NOTARIZE_PASSWORD }}
+
+   - uses: s3-actions/s3cmd@v1.2.0
+     if: steps.iamafork.outputs.IAMAFORK == 'false'
+     with:
+       provider: aws
+       region: us-east-1
+       access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+       secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+   - name: upload snapshots
+     if: steps.iamafork.outputs.IAMAFORK == 'false'
+     run: |
+       s3cmd put -P *.${{env.target}} s3://redismodules/redis-stack/snapshots/
+       s3cmd put -P *.sha256 s3://redismodules/redis-stack/snapshots/
+
+ test-osx-m1:
+   name: Mac (M1) tests
+   needs: [build-package-osx-m1]
+   env:
+     arch: arm64
+     osnick: monterey
+     target: zip
+     platform: monterey
+     osname: macos
+     pythonversion: "3.10"
+   runs-on: ubuntu-latest
+   steps:
+     - name: determine if in fork
+       id: iamafork
+       run: |
+         amfork=`jq '.pull_request.head.repo.fork' $GITHUB_EVENT_PATH`
+         echo "am I fork: ${amfork}"
+         echo "IAMAFORK=$amfork" >> $GITHUB_OUTPUT
+
+     - name: checkout sources
+       uses: actions/checkout@v3
+     - name: Cache dependencies
+       uses: actions/cache@v3
+       with:
+         path: |
+           /var/cache/apt/archives/**.deb
+           ~/.cache/pip
+           ~/.cache/pypoetry
+           ~/.local/share/gem
+           poetry.lock
+         key: pypoetry-${{hashFiles('**/pyproject.toml')}}-${{env.platform}}-${{env.arch}}-package
+     - name: install python
+       uses: actions/setup-python@v4
+       with:
+         python-version: "${{ env.pythonversion }}"
+     - name: install poetry
+       uses: snok/install-poetry@v1
+       with:
+         version: latest
+         virtualenvs-in-project: true
+         virtualenvs-create: true
+         installer-parallel: true
+     - name: gather artifacts
+       uses: actions/download-artifact@v3
+       with:
+         name: redis-stack-server-${{env.platform}}-${{env.arch}}.${{env.target}}
+
+     - name: write the ssh key to a file
+       if: steps.iamafork.outputs.IAMAFORK == 'false'
+       run: |
+         echo "${{secrets.OPERETO_KEY}}" > ssh.key
+         chmod 0400 ssh.key
+
+     - name: get package version
+       id: get_version
+       run: |
+         poetry install
+         source .venv/bin/activate
+         realversion=`invoke version`
+         echo "VERSION=$realversion" >> $GITHUB_OUTPUT
+
+     - name: run the tests
+       if: steps.iamafork.outputs.IAMAFORK == 'false'
+       run: |
+         source .venv/bin/activate
+         invoke test-over-ssh -b \
+           redis-stack-server-${{steps.get_version.outputs.VERSION}}.${{env.platform}}.${{env.arch}}.${{env.target}} \
+           -i ${{secrets.M1_IP}} \
+           -m macos \
+           -p redis-stack-server \
+           -s ssh.key \
+           -u ${{secrets.M1_SSH_USER}} \
+           -v `echo $RANDOM` \
+           -g ${{github.head_ref}}
 
 ###################### COLLATE DOCKERS ##################
  docker-push:

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -18,22 +18,22 @@ on:
 jobs:
 
 ###################### ARM JOBS #########################
- arm64-bionic:
-   uses: ./.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
-   with:
-     image_name: ubuntu:bionic
-     platform: bionic
-     osname: Linux
-     osnick: ubuntu18.04
-     arch: arm64
-     target: deb
-     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip
-     pythonversion: "3.10"
-   secrets:
-     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-     GPG_KEY: ${{ secrets.GPG_KEY }}
-     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+# arm64-bionic:
+#   uses: ./.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
+#   with:
+#     image_name: ubuntu:bionic
+#     platform: bionic
+#     osname: Linux
+#     osnick: ubuntu18.04
+#     arch: arm64
+#     target: deb
+#     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip
+#     pythonversion: "3.10"
+#   secrets:
+#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#     GPG_KEY: ${{ secrets.GPG_KEY }}
+#     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
 
  arm64-focal:
@@ -53,22 +53,22 @@ jobs:
      GPG_KEY: ${{ secrets.GPG_KEY }}
      GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
- arm64-jammy:
-   uses: ./.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
-   with:
-     image_name: ubuntu:jammy
-     platform: jammy
-     osname: Linux
-     osnick: ubuntu22.04
-     arch: arm64
-     target: deb
-     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip
-     pythonversion: "3.10"
-   secrets:
-     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-     GPG_KEY: ${{ secrets.GPG_KEY }}
-     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+# arm64-jammy:
+#   uses: ./.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
+#   with:
+#     image_name: ubuntu:jammy
+#     platform: jammy
+#     osname: Linux
+#     osnick: ubuntu22.04
+#     arch: arm64
+#     target: deb
+#     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip
+#     pythonversion: "3.10"
+#   secrets:
+#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#     GPG_KEY: ${{ secrets.GPG_KEY }}
+#     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
  arm64-focal-redisinsight-web:
    uses: ./.github/workflows/REDISINSIGHT_WEB_REUSABLE.yml
@@ -96,17 +96,17 @@ jobs:
      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_REDISFAB_USERNAME }}
      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_REDISFAB_TOKEN }}
 
- arm64-snap:
-   uses: ./.github/workflows/SNAP_REUSABLE.yml
-   needs: [arm64-bionic]
-   with:
-     arch: arm64
-     platform: bionic
-     osnick: ubuntu18.04
-     pythonversion: "3.10"
-   secrets:
-     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+# arm64-snap:
+#   uses: ./.github/workflows/SNAP_REUSABLE.yml
+#   needs: [arm64-bionic]
+#   with:
+#     arch: arm64
+#     platform: bionic
+#     osnick: ubuntu18.04
+#     pythonversion: "3.10"
+#   secrets:
+#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
 
 # ##################### x86_64 JOBS #########################
@@ -141,22 +141,22 @@ jobs:
      GPG_KEY: ${{ secrets.GPG_KEY }}
      GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
- x86_64-jammy:
-   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
-   with:
-     image_name: ubuntu:jammy
-     platform: jammy
-     osname: Linux
-     osnick: ubuntu22.04
-     arch: x86_64
-     target: deb
-     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
-     pythonversion: "3.10"
-   secrets:
-     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-     GPG_KEY: ${{ secrets.GPG_KEY }}
-     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+# x86_64-jammy:
+#   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+#   with:
+#     image_name: ubuntu:jammy
+#     platform: jammy
+#     osname: Linux
+#     osnick: ubuntu22.04
+#     arch: x86_64
+#     target: deb
+#     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
+#     pythonversion: "3.10"
+#   secrets:
+#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#     GPG_KEY: ${{ secrets.GPG_KEY }}
+#     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
  x86_64-docker:
    uses: ./.github/workflows/DOCKER_REUSABLE.yml
@@ -169,724 +169,724 @@ jobs:
      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_REDISFAB_USERNAME }}
      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_REDISFAB_TOKEN }}
 
- x86_64-snap:
-   uses: ./.github/workflows/SNAP_REUSABLE.yml
-   needs: [x86_64-focal]
-   with:
-     arch: x86_64
-     platform: focal
-     osnick: ubuntu20.04
-     pythonversion: "3.10"
-   secrets:
-     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
- x86_64-appimage:
-   uses: ./.github/workflows/APPIMAGE_REUSABLE.yml
-   needs: [x86_64-bionic]
-   with:
-     arch: x86_64
-     platform: bionic
-     osnick: ubuntu18.04
-     pythonversion: "3.10"
-   secrets:
-     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
- x86_64-bionic:
-   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
-   with:
-     image_name: ubuntu:bionic
-     platform: bionic
-     osname: Linux
-     osnick: ubuntu18.04
-     arch: x86_64
-     target: deb
-     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
-     pythonversion: "3.10"
-   secrets:
-     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-     GPG_KEY: ${{ secrets.GPG_KEY }}
-     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-
- x86_64-xenial:
-   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
-   with:
-     image_name: ubuntu:xenial
-     platform: xenial
-     osname: Linux
-     osnick: ubuntu16.04
-     arch: x86_64
-     target: deb
-     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
-     pythonversion: "3.10"
-   secrets:
-     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-     GPG_KEY: ${{ secrets.GPG_KEY }}
-     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-
-#  # uses precompiled ubuntu binaries, hence the testplatform override
-# x86_64-archlinux:
+# x86_64-snap:
+#   uses: ./.github/workflows/SNAP_REUSABLE.yml
+#   needs: [x86_64-focal]
+#   with:
+#     arch: x86_64
+#     platform: focal
+#     osnick: ubuntu20.04
+#     pythonversion: "3.10"
+#   secrets:
+#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#
+# x86_64-appimage:
+#   uses: ./.github/workflows/APPIMAGE_REUSABLE.yml
+#   needs: [x86_64-bionic]
+#   with:
+#     arch: x86_64
+#     platform: bionic
+#     osnick: ubuntu18.04
+#     pythonversion: "3.10"
+#   secrets:
+#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#
+# x86_64-bionic:
 #   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
 #   with:
-#     image_name: archlinux:latest
-#     platform: focal
-#     testplatform: archlinux
-#     osnick: ubuntu20.04
-#     arch: x86_64
+#     image_name: ubuntu:bionic
+#     platform: bionic
 #     osname: Linux
-#     target: pkg
-#     build_deps: pacman -Syyu --noconfirm gcc gcc-libs git openssl jq wget python python-pip openssh make
+#     osnick: ubuntu18.04
+#     arch: x86_64
+#     target: deb
+#     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
 #     pythonversion: "3.10"
 #   secrets:
 #     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
 #     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 #     GPG_KEY: ${{ secrets.GPG_KEY }}
 #     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-
- bullseye:
-   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
-   with:
-     image_name: debian:bullseye-slim
-     platform: bullseye
-     osname: Linux
-     osnick: bullseye
-     arch: x86_64
-     target: deb
-     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
-     pythonversion: "3.10"
-   secrets:
-     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-     GPG_KEY: ${{ secrets.GPG_KEY }}
-     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-
- x86_64-rhel7:
-   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
-   with:
-     image_name: centos:7
-     platform: rhel7
-     osname: Linux
-     osnick: rhel7
-     arch: x86_64
-     target: rpm
-     build_deps: |
-      yum install -y epel-release
-      yum install -y gcc make jemalloc-devel openssl-devel python3 python3-pip jq wget
-     pythonversion: "3.10"
-   secrets:
-     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-     GPG_KEY: ${{ secrets.GPG_KEY }}
-     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-
- x86_64_amazonlinux2:
-  name: Amazonlinux2 (x86_64)
-  runs-on: ubuntu-latest
-  needs: [ x86_64-rhel7 ]
-  strategy:
-    matrix:
-      package: ['redis-stack-server']  # add the matrix back if multiple packages are a thing again
-  env:
-    arch: x86_64
-    platform: rhel7
-    testplatform: amazonlinux2
-    osnick: rhel7
-    osname: Linux
-    target: rpm
-    pythonversion: "3.10"
-  steps:
-
-   - name: checkout sources
-     uses: actions/checkout@v3
-   - name: Cache dependencies
-     uses: actions/cache@v3
-     with:
-       path: |
-         /var/cache/apt/archives/**.deb
-         /var/cache/yum
-         ~/.cache/pip
-         ~/.cache/pypoetry
-         ~/.local/share/gem
-       key: pypoetry-${{hashFiles('pyproject.toml', '.github/workflows/*.yml')}}-${{env.platform}}-${{env.arch}}-package
-   - name: install python
-     uses: actions/setup-python@v4
-     with:
-       python-version: "${{env.pythonversion}}"
-   - name: install poetry
-     uses: snok/install-poetry@v1
-     with:
-       version: latest
-       virtualenvs-in-project: true
-       virtualenvs-create: true
-       installer-parallel: true
-
-   - name: install packaging and testing tools
-     run: |
-       poetry install
-
-   - uses: actions/download-artifact@v3
-     with:
-       name: redis-stack-server-${{env.platform}}-${{env.arch}}.${{env.target}}
-
-   - uses: actions/download-artifact@v3
-     with:
-       name: redis-stack-server-${{env.platform}}-${{env.arch}}.tar.gz
-
-   - name: run tests in dockers
-     run: |
-       source .venv/bin/activate
-       mkdir redis-stack
-       cp *.tar.gz redis-stack/${{ matrix.package }}.tar.gz
-       cp *.${{ env.target }} redis-stack/${{ matrix.package }}.${{ env.target }}
-       pytest -m "${{env.testplatform}} and not physical and not arm" --junit-xml=results.xml
-
-   - uses: dorny/test-reporter@v1
-     if: success() || failure()
-     with:
-       name: Test Results ${{env.testplatform}} ${{env.osnick}} ${{env.arch}}
-       path: '*.xml'
-       reporter: java-junit
-       list-suites: all
-       list-tests: all
-       max-annotations: 10
-
- x86-64_rhel8:
-   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
-   with:
-     image_name: oraclelinux:8
-     platform: rhel8
-     osname: Linux
-     osnick: rhel8
-     arch: x86_64
-     target: rpm
-     pythonversion: "3.10"
-     build_deps: |
-       dnf install -y oracle-epel-release-el8
-       dnf install -y gcc make jemalloc-devel openssl-devel tar git python3 python3-pip jq wget
-   secrets:
-     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-     GPG_KEY: ${{ secrets.GPG_KEY }}
-     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
-
-##################### OSX JOBS #########################
-
-# osx is the only one of these that is really
- build-package-osx:
-
-   name: Mac (x86_64) Build
-   env:
-     arch: x86_64
-     osnick: catalina
-     target: zip
-     platform: catalina
-     osname: macos
-     pythonversion: "3.10"
-     fpmversion: 1.14.2
-     rubyversion: 2.7.2
-
-   runs-on: macos-latest
-
-   steps:
-   - name: determine if in fork
-     id: iamafork
-     run: |
-       amfork=`jq '.pull_request.head.repo.fork' $GITHUB_EVENT_PATH`
-       echo "am I fork: ${amfork}"
-       echo "IAMAFORK=$amfork" >> $GITHUB_OUTPUT
-
-   - name: checkout sources
-     uses: actions/checkout@v3
-     with:
-       path: redis-stack
-
-   - name: get versions from config file
-     id: get_config_versions
-     run: |
-       echo PACKAGEDREDISVERSION=`grep -w "packagedredisversion" redis-stack/config.yml | cut -d ":" -f 2-2|tr -d ' '` >> $GITHUB_OUTPUT
-       echo REDISVERSION=`grep -w "redis:" redis-stack/config.yml | cut -d ":" -f 2-2|tr -d ' '` >> $GITHUB_OUTPUT
-
-   - name: check if already built
-     id: redis-already-built
-     continue-on-error: true
-     run: |
-       wget -q https://redismodules.s3.amazonaws.com/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz
-
-   - uses: ruby/setup-ruby@v1
-     with:
-       ruby-version: ${{env.rubyversion}}
-   - name: install python
-     uses: actions/setup-python@v4
-     with:
-       python-version: "${{ env.pythonversion }}"
-   - name: install poetry
-     uses: snok/install-poetry@v1
-     with:
-       version: latest
-       virtualenvs-in-project: true
-       virtualenvs-create: true
-       installer-parallel: true
-
-   - name: clone redis
-     if: steps.redis-already-built.outcome != 'success'
-     uses: actions/checkout@v3
-     with:
-       repository: redis/redis
-       path: redis
-       ref: ${{steps.get_config_versions.outputs.REDISVERSION}}
-
-   - name: install dependencies
-     run: |
-       brew install openssl@3
-       gem install fpm -v ${{env.fpmversion}}
-       cd redis-stack
-       poetry install
-   - name: build redis from source
-     if: steps.redis-already-built.outcome != 'success'
-     run: |
-       cd redis
-       make all BUILD_TLS=yes FINAL_LIBS="-lm -ldl ../deps/hiredis/libhiredis_ssl.a /usr/local/opt/openssl/lib/libssl.a /usr/local/opt/openssl/lib/libcrypto.a"
-
-   - name: package redis for s3
-     if: steps.redis-already-built.outcome != 'success'
-     run: |
-       mkdir redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}
-       cp redis/src/redis-server \
-           redis/src/redis-sentinel \
-           redis/src/redis-check-aof \
-           redis/src/redis-check-rdb \
-           redis/src/redis-benchmark \
-           redis/src/redis-cli \
-           redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}
-       tar -czvf redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz \
-           redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}
-
-   - uses: s3-actions/s3cmd@v1.2.0
-     with:
-       provider: aws
-       region: us-east-1
-       access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
-       secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-   - name: persist redis to s3
-     if: steps.redis-already-built.outcome != 'success' && steps.iamafork.outputs.IAMAFORK == 'false'
-     run: |
-       s3cmd put -P redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz \
-       s3://redismodules/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz
-
-   - name: perist redis
-     if: steps.redis-already-built.outcome != 'success'
-     uses: actions/upload-artifact@v3
-     with:
-       name: redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-osx
-       path: |
-         redis/src/redis-server
-         redis/src/redis-sentinel
-         redis/src/redis-check-aof
-         redis/src/redis-check-rdb
-         redis/src/redis-benchmark
-         redis/src/redis-cli
-
-   - name: collect dependencies prior to zipping
-     run: |
-       cd redis-stack
-       source .venv/bin/activate
-       invoke package -o ${{env.osname}} -s ${{env.osnick}} -d ${{env.platform}} -a ${{env.arch}} -t zip -p redis-stack-server -k package
-
-   - name: codesign all binaries
-     if: steps.iamafork.outputs.IAMAFORK == 'false'
-     run: |
-       cd redis-stack
-       echo ${{secrets.MACOS_CERTIFICATE}} | base64 --decode > certificate.p12
-       security create-keychain -p ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
-       security default-keychain -s build.keychain
-       security unlock-keychain -p ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
-       security import certificate.p12 -k build.keychain -P ${{ secrets.MACOS_CERTIFICATE_PASSWORD }} -T /usr/bin/codesign
-       security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
-       CODESIGN_IDENTITY=`security find-identity -v|head -n 1|awk '{print $2}'`
-       for i in `ls build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/bin`; do
-         /usr/bin/codesign --options=runtime --timestamp -v --sign ${CODESIGN_IDENTITY} --entitlements etc/entitlements -f build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/bin/$i
-       done
-       for i in `ls build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/lib`; do
-         /usr/bin/codesign --options=runtime --timestamp -v --sign ${CODESIGN_IDENTITY} --entitlements etc/entitlements -f build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/lib/$i
-       done
-
-   - name: build the redis-stack-server zipfile (for homebrew)
-     run: |
-       cd redis-stack
-       source .venv/bin/activate
-       invoke package -o ${{env.osname}} -s ${{env.osnick}} -d ${{env.platform}} -a ${{env.arch}} -r ../redis/src -t zip -p redis-stack-server -k fetch
-
-   - name: perist the zipfile
-     uses: actions/upload-artifact@v3
-     with:
-       name: redis-stack-${{env.platform}}-${{env.arch}}.${{env.target}}
-       path: |
-         redis-stack/redis-stack-*.zip
-
-   - name: create the zip for notarization
-     run: |
-       cd redis-stack/build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack
-       zip -r notarized-${{env.platform}}-${{env.arch}}.zip bin lib
-
-   - name: notarize the custom zip
-     if: steps.iamafork.outputs.IAMAFORK == 'false'
-     run: |
-       cd redis-stack/build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack
-       sh ../../../../notarize.sh notarized-${{env.platform}}-${{env.arch}}.zip com.redis.redis-stack-server ${{ secrets.MAC_NOTARIZE_USERNAME }} ${{ secrets.MAC_NOTARIZE_PASSWORD }}
-
- test-osx-intel:
-   name: Mac (x86_64) Tests
-   needs: ['build-package-osx']
-   runs-on: macos-latest
-   env:
-     arch: x86_64
-     osnick: catalina
-     target: zip
-     platform: catalina
-     osname: macos
-     pythonversion: "3.10"
-
-   steps:
-   - name: determine if in fork
-     id: iamafork
-     run: |
-       amfork=`jq '.pull_request.head.repo.fork' $GITHUB_EVENT_PATH`
-       echo "am I fork: ${amfork}"
-       echo "IAMAFORK=$amfork" >> $GITHUB_OUTPUT
-
-   - name: install python
-     uses: actions/setup-python@v4
-     with:
-       python-version: "${{ env.pythonversion }}"
-   - name: install poetry
-     uses: snok/install-poetry@v1
-     with:
-       version: latest
-       virtualenvs-in-project: true
-       virtualenvs-create: true
-       installer-parallel: true
-   - name: checkout sources
-     uses: actions/checkout@v3
-   - name: install dependencies
-     run: |
-       brew install libomp openssl coreutils
-       poetry install
-   - name: gather artifacts
-     uses: actions/download-artifact@v3
-     with:
-       path: redis-stack
-       name: redis-stack-${{env.platform}}-${{env.arch}}.${{env.target}}
-   - name: unzip the zipfile
-     run: |
-       ls -R
-       mkdir -p redis-stack
-       unzip redis-stack/redis-stack*.${{env.target}} -d redis-stack/redis-stack-server
-
-   - name: run osx tests
-     run: |
-       .venv/bin/pytest -m macos --junit-xml=results.xml
-   - uses: dorny/test-reporter@v1
-     if: success() || failure()
-     with:
-       name: Test Results ${{env.platform}} ${{env.osnick}} ${{env.arch}}
-       path: '*.xml'
-       reporter: java-junit
-       list-suites: all
-       list-tests: all
-       max-annotations: 10
-
-   - name: get package version
-     id: get_version
-     run: |
-       poetry install
-       source .venv/bin/activate
-       realversion=`invoke version`
-       echo "VERSION=$realversion" >> $GITHUB_OUTPUT
-
-   - uses: s3-actions/s3cmd@v1.2.0
-     if: steps.iamafork.outputs.IAMAFORK == 'false'
-     with:
-       provider: aws
-       region: us-east-1
-       access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
-       secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-   - name: persist redis to s3
-     if: steps.iamafork.outputs.IAMAFORK == 'false'
-     run: |
-      mkdir s3dist
-      cp redis-stack/redis-stack*.${{env.target}} s3dist
-      for i in `ls s3dist`; do
-        sha256sum s3dist/$i | awk '{print $1}' > s3dist/$i.sha256
-      done
-      s3cmd put -P s3dist/* s3://redismodules/redis-stack/snapshots/
-
- # the m1 requires a zip file so that homebrew can unpack it
- build-package-osx-m1:
-   name: Mac (M1) Package
-   env:
-     arch: arm64
-     osnick: monterey
-     target: zip
-     platform: monterey
-     osname: macos
-     pythonversion: "3.10"
-     fpmversion: 1.14.2
-     rubyversion: 2.7.2
-   runs-on: macos-latest
-   steps:
-   - name: checkout sources
-     uses: actions/checkout@v3
-   - uses: ruby/setup-ruby@v1
-     with:
-       ruby-version: ${{env.rubyversion}}
-   - name: install python
-     uses: actions/setup-python@v4
-     with:
-       python-version: "${{ env.pythonversion }}"
-   - name: install dependencies
-     run: |
-       brew install coreutils
-   - name: install poetry
-     uses: snok/install-poetry@v1
-     with:
-       version: latest
-       virtualenvs-in-project: true
-       virtualenvs-create: true
-       installer-parallel: true
-   - name: Cache dependencies
-     uses: actions/cache@v3
-     with:
-       path: |
-         /var/cache/apt/archives/**.deb
-         ~/.cache/pip
-         ~/.cache/pypoetry
-         ~/.local/share/gem
-       key: pypoetry-${{hashFiles('**/pyproject.toml')}}-${{env.platform}}-${{env.arch}}-package
-   - name: install packaging tools
-     run: |
-       gem install fpm -v ${{env.fpmversion}}
-       poetry install
-
-   - name: determine if in fork
-     id: iamafork
-     run: |
-       amfork=`jq '.pull_request.head.repo.fork' $GITHUB_EVENT_PATH`
-       echo "am I fork: ${amfork}"
-       echo "IAMAFORK=$amfork" >> $GITHUB_OUTPUT
-
-   - name: write the ssh key to a file
-     if: steps.iamafork.outputs.IAMAFORK == 'false'
-     run: |
-       echo "${{secrets.OPERETO_KEY}}" > ssh.key
-       chmod 0400 ssh.key
-
-   - name: get versions from config file
-     id: get_config_versions
-     run: |
-       echo PACKAGEDREDISVERSION=`grep -w "packagedredisversion" config.yml | cut -d ":" -f 2-2|tr -d ' '` >> $GITHUB_OUTPUT
-       echo REDISVERSION=`grep -w "redis:" config.yml | cut -d ":" -f 2-2|tr -d ' '` >> $GITHUB_OUTPUT
-
-   - name: check if already built
-     id: redis-already-built
-     continue-on-error: true
-     run: |
-       wget -q https://redismodules.s3.amazonaws.com/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz
-
-   - name: build redis from source
-     if: steps.redis-already-built.outcome != 'success' && steps.iamafork.outputs.IAMAFORK == 'false'
-     run: |
-       source .venv/bin/activate
-       invoke build-m1-over-ssh \
-        -i ${{ secrets.M1_IP }} \
-        -u ${{ secrets.M1_SSH_USER }} \
-        -s ssh.key \
-        -v ${{ steps.get_config_versions.outputs.REDISVERSION }} \
-        -p ${{ steps.get_config_versions.outputs.PACKAGEDREDISVERSION }}
-
-   - name: package redis for s3
-     if: steps.redis-already-built.outcome != 'success'
-     run: |
-       tar -czvf redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz \
-           redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}
-   - uses: s3-actions/s3cmd@v1.2.0
-     with:
-       provider: aws
-       region: us-east-1
-       access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
-       secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-
-   - name: persist redis to s3
-     if: steps.redis-already-built.outcome != 'success' && steps.iamafork.outputs.IAMAFORK == 'false'
-     run: |
-       s3cmd put -P redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz \
-       s3://redismodules/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz
-
-   - name: perist redis
-     if: steps.redis-already-built.outcome != 'success'
-     uses: actions/upload-artifact@v3
-     with:
-       name: redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.arch}}-osx
-       path: |
-         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-server
-         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-sentinel
-         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-check-aof
-         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-check-rdb
-         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-benchmark
-         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-cli
-
-### Once https://github.com/actions/runner/issues/805 is resolved we can do this ###
-### For now, this is how it is manually built, on the platform ###
-#    - name: build redis from source
-#      run: |
-#        cd redis
-#        make all BUILD_TLS=yes FINAL_LIBS="-lm -ldl ../deps/hiredis/libhiredis_ssl.a /opt/homebrew/opt/openssl/lib/libssl.a /opt/homebrew/opt/openssl/lib/libcrypto.a" CFLAGS="-I /opt/homebrew/opt/openssl@3/include"
 #
-   - name: collect dependencies prior to packaging
-     run: |
-       source .venv/bin/activate
-       invoke package -o ${{env.osname}} -s ${{env.osnick}} -d ${{env.platform}} -a ${{env.arch}} -t ${{env.target}} -p redis-stack-server -k package
-
-   - name: codesign all binaries
-     if: steps.iamafork.outputs.IAMAFORK == 'false'
-     run: |
-       echo ${{secrets.MACOS_CERTIFICATE}} | base64 --decode > certificate.p12
-       security create-keychain -p ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
-       security default-keychain -s build.keychain
-       security unlock-keychain -p ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
-       security import certificate.p12 -k build.keychain -P ${{ secrets.MACOS_CERTIFICATE_PASSWORD }} -T /usr/bin/codesign
-       security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
-       CODESIGN_IDENTITY=`security find-identity -v|head -n 1|awk '{print $2}'`
-       for i in `ls build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/bin`; do
-         /usr/bin/codesign --options=runtime --timestamp -v --sign ${CODESIGN_IDENTITY} --entitlements etc/entitlements -f build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/bin/$i
-       done
-       for i in `ls build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/lib`; do
-         /usr/bin/codesign --options=runtime --timestamp -v --sign ${CODESIGN_IDENTITY} --entitlements etc/entitlements -f build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/lib/$i
-       done
-
-   - name: build redis-stack-server zipfile
-     run: |
-       source .venv/bin/activate
-       invoke package -o ${{env.osname}} -s ${{env.osnick}} -d ${{env.platform}} -a ${{env.arch}} -t ${{env.target}} -p redis-stack-server -k fetch
-       for i in `ls *.zip`; do
-         sha256sum $i |awk '{print $1}' > $i.sha256
-       done
-
-   - name: persist the zipfile
-     uses: actions/upload-artifact@v3
-     with:
-       name: redis-stack-server-${{env.platform}}-${{env.arch}}.${{env.target}}
-       path: |
-         *.zip
-
-   - name: create the zip for notarization
-     run: |
-       cd build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack
-       zip -r notarized-${{env.platform}}-${{env.arch}}.zip bin lib
-
-   - name: persist the codesigned artifacts
-     uses: actions/upload-artifact@v3
-     with:
-       name: codesigned-${{env.platform}}-${{env.arch}}
-       path: |
-         build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/*.zip
-
-   - name: notarize the custom zip
-     if: steps.iamafork.outputs.IAMAFORK == 'false'
-     run: |
-       cd build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack
-       sh ../../../../notarize.sh notarized-${{env.platform}}-${{env.arch}}.zip com.redis.redis-stack-server ${{ secrets.MAC_NOTARIZE_USERNAME }} ${{ secrets.MAC_NOTARIZE_PASSWORD }}
-
-   - uses: s3-actions/s3cmd@v1.2.0
-     if: steps.iamafork.outputs.IAMAFORK == 'false'
-     with:
-       provider: aws
-       region: us-east-1
-       access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
-       secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-   - name: upload snapshots
-     if: steps.iamafork.outputs.IAMAFORK == 'false'
-     run: |
-       s3cmd put -P *.${{env.target}} s3://redismodules/redis-stack/snapshots/
-       s3cmd put -P *.sha256 s3://redismodules/redis-stack/snapshots/
-
- test-osx-m1:
-   name: Mac (M1) tests
-   needs: [build-package-osx-m1]
-   env:
-     arch: arm64
-     osnick: monterey
-     target: zip
-     platform: monterey
-     osname: macos
-     pythonversion: "3.10"
-   runs-on: ubuntu-latest
-   steps:
-     - name: determine if in fork
-       id: iamafork
-       run: |
-         amfork=`jq '.pull_request.head.repo.fork' $GITHUB_EVENT_PATH`
-         echo "am I fork: ${amfork}"
-         echo "IAMAFORK=$amfork" >> $GITHUB_OUTPUT
-
-     - name: checkout sources
-       uses: actions/checkout@v3
-     - name: Cache dependencies
-       uses: actions/cache@v3
-       with:
-         path: |
-           /var/cache/apt/archives/**.deb
-           ~/.cache/pip
-           ~/.cache/pypoetry
-           ~/.local/share/gem
-           poetry.lock
-         key: pypoetry-${{hashFiles('**/pyproject.toml')}}-${{env.platform}}-${{env.arch}}-package
-     - name: install python
-       uses: actions/setup-python@v4
-       with:
-         python-version: "${{ env.pythonversion }}"
-     - name: install poetry
-       uses: snok/install-poetry@v1
-       with:
-         version: latest
-         virtualenvs-in-project: true
-         virtualenvs-create: true
-         installer-parallel: true
-     - name: gather artifacts
-       uses: actions/download-artifact@v3
-       with:
-         name: redis-stack-server-${{env.platform}}-${{env.arch}}.${{env.target}}
-
-     - name: write the ssh key to a file
-       if: steps.iamafork.outputs.IAMAFORK == 'false'
-       run: |
-         echo "${{secrets.OPERETO_KEY}}" > ssh.key
-         chmod 0400 ssh.key
-
-     - name: get package version
-       id: get_version
-       run: |
-         poetry install
-         source .venv/bin/activate
-         realversion=`invoke version`
-         echo "VERSION=$realversion" >> $GITHUB_OUTPUT
-
-     - name: run the tests
-       if: steps.iamafork.outputs.IAMAFORK == 'false'
-       run: |
-         source .venv/bin/activate
-         invoke test-over-ssh -b \
-           redis-stack-server-${{steps.get_version.outputs.VERSION}}.${{env.platform}}.${{env.arch}}.${{env.target}} \
-           -i ${{secrets.M1_IP}} \
-           -m macos \
-           -p redis-stack-server \
-           -s ssh.key \
-           -u ${{secrets.M1_SSH_USER}} \
-           -v `echo $RANDOM` \
-           -g ${{github.head_ref}}
+# x86_64-xenial:
+#   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+#   with:
+#     image_name: ubuntu:xenial
+#     platform: xenial
+#     osname: Linux
+#     osnick: ubuntu16.04
+#     arch: x86_64
+#     target: deb
+#     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
+#     pythonversion: "3.10"
+#   secrets:
+#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#     GPG_KEY: ${{ secrets.GPG_KEY }}
+#     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+#
+##  # uses precompiled ubuntu binaries, hence the testplatform override
+## x86_64-archlinux:
+##   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+##   with:
+##     image_name: archlinux:latest
+##     platform: focal
+##     testplatform: archlinux
+##     osnick: ubuntu20.04
+##     arch: x86_64
+##     osname: Linux
+##     target: pkg
+##     build_deps: pacman -Syyu --noconfirm gcc gcc-libs git openssl jq wget python python-pip openssh make
+##     pythonversion: "3.10"
+##   secrets:
+##     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+##     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+##     GPG_KEY: ${{ secrets.GPG_KEY }}
+##     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+#
+# bullseye:
+#   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+#   with:
+#     image_name: debian:bullseye-slim
+#     platform: bullseye
+#     osname: Linux
+#     osnick: bullseye
+#     arch: x86_64
+#     target: deb
+#     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
+#     pythonversion: "3.10"
+#   secrets:
+#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#     GPG_KEY: ${{ secrets.GPG_KEY }}
+#     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+#
+# x86_64-rhel7:
+#   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+#   with:
+#     image_name: centos:7
+#     platform: rhel7
+#     osname: Linux
+#     osnick: rhel7
+#     arch: x86_64
+#     target: rpm
+#     build_deps: |
+#      yum install -y epel-release
+#      yum install -y gcc make jemalloc-devel openssl-devel python3 python3-pip jq wget
+#     pythonversion: "3.10"
+#   secrets:
+#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#     GPG_KEY: ${{ secrets.GPG_KEY }}
+#     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+#
+# x86_64_amazonlinux2:
+#  name: Amazonlinux2 (x86_64)
+#  runs-on: ubuntu-latest
+#  needs: [ x86_64-rhel7 ]
+#  strategy:
+#    matrix:
+#      package: ['redis-stack-server']  # add the matrix back if multiple packages are a thing again
+#  env:
+#    arch: x86_64
+#    platform: rhel7
+#    testplatform: amazonlinux2
+#    osnick: rhel7
+#    osname: Linux
+#    target: rpm
+#    pythonversion: "3.10"
+#  steps:
+#
+#   - name: checkout sources
+#     uses: actions/checkout@v3
+#   - name: Cache dependencies
+#     uses: actions/cache@v3
+#     with:
+#       path: |
+#         /var/cache/apt/archives/**.deb
+#         /var/cache/yum
+#         ~/.cache/pip
+#         ~/.cache/pypoetry
+#         ~/.local/share/gem
+#       key: pypoetry-${{hashFiles('pyproject.toml', '.github/workflows/*.yml')}}-${{env.platform}}-${{env.arch}}-package
+#   - name: install python
+#     uses: actions/setup-python@v4
+#     with:
+#       python-version: "${{env.pythonversion}}"
+#   - name: install poetry
+#     uses: snok/install-poetry@v1
+#     with:
+#       version: latest
+#       virtualenvs-in-project: true
+#       virtualenvs-create: true
+#       installer-parallel: true
+#
+#   - name: install packaging and testing tools
+#     run: |
+#       poetry install
+#
+#   - uses: actions/download-artifact@v3
+#     with:
+#       name: redis-stack-server-${{env.platform}}-${{env.arch}}.${{env.target}}
+#
+#   - uses: actions/download-artifact@v3
+#     with:
+#       name: redis-stack-server-${{env.platform}}-${{env.arch}}.tar.gz
+#
+#   - name: run tests in dockers
+#     run: |
+#       source .venv/bin/activate
+#       mkdir redis-stack
+#       cp *.tar.gz redis-stack/${{ matrix.package }}.tar.gz
+#       cp *.${{ env.target }} redis-stack/${{ matrix.package }}.${{ env.target }}
+#       pytest -m "${{env.testplatform}} and not physical and not arm" --junit-xml=results.xml
+#
+#   - uses: dorny/test-reporter@v1
+#     if: success() || failure()
+#     with:
+#       name: Test Results ${{env.testplatform}} ${{env.osnick}} ${{env.arch}}
+#       path: '*.xml'
+#       reporter: java-junit
+#       list-suites: all
+#       list-tests: all
+#       max-annotations: 10
+#
+# x86-64_rhel8:
+#   uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+#   with:
+#     image_name: oraclelinux:8
+#     platform: rhel8
+#     osname: Linux
+#     osnick: rhel8
+#     arch: x86_64
+#     target: rpm
+#     pythonversion: "3.10"
+#     build_deps: |
+#       dnf install -y oracle-epel-release-el8
+#       dnf install -y gcc make jemalloc-devel openssl-devel tar git python3 python3-pip jq wget
+#   secrets:
+#     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#     GPG_KEY: ${{ secrets.GPG_KEY }}
+#     GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
+#
+###################### OSX JOBS #########################
+#
+## osx is the only one of these that is really
+# build-package-osx:
+#
+#   name: Mac (x86_64) Build
+#   env:
+#     arch: x86_64
+#     osnick: catalina
+#     target: zip
+#     platform: catalina
+#     osname: macos
+#     pythonversion: "3.10"
+#     fpmversion: 1.14.2
+#     rubyversion: 2.7.2
+#
+#   runs-on: macos-latest
+#
+#   steps:
+#   - name: determine if in fork
+#     id: iamafork
+#     run: |
+#       amfork=`jq '.pull_request.head.repo.fork' $GITHUB_EVENT_PATH`
+#       echo "am I fork: ${amfork}"
+#       echo "IAMAFORK=$amfork" >> $GITHUB_OUTPUT
+#
+#   - name: checkout sources
+#     uses: actions/checkout@v3
+#     with:
+#       path: redis-stack
+#
+#   - name: get versions from config file
+#     id: get_config_versions
+#     run: |
+#       echo PACKAGEDREDISVERSION=`grep -w "packagedredisversion" redis-stack/config.yml | cut -d ":" -f 2-2|tr -d ' '` >> $GITHUB_OUTPUT
+#       echo REDISVERSION=`grep -w "redis:" redis-stack/config.yml | cut -d ":" -f 2-2|tr -d ' '` >> $GITHUB_OUTPUT
+#
+#   - name: check if already built
+#     id: redis-already-built
+#     continue-on-error: true
+#     run: |
+#       wget -q https://redismodules.s3.amazonaws.com/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz
+#
+#   - uses: ruby/setup-ruby@v1
+#     with:
+#       ruby-version: ${{env.rubyversion}}
+#   - name: install python
+#     uses: actions/setup-python@v4
+#     with:
+#       python-version: "${{ env.pythonversion }}"
+#   - name: install poetry
+#     uses: snok/install-poetry@v1
+#     with:
+#       version: latest
+#       virtualenvs-in-project: true
+#       virtualenvs-create: true
+#       installer-parallel: true
+#
+#   - name: clone redis
+#     if: steps.redis-already-built.outcome != 'success'
+#     uses: actions/checkout@v3
+#     with:
+#       repository: redis/redis
+#       path: redis
+#       ref: ${{steps.get_config_versions.outputs.REDISVERSION}}
+#
+#   - name: install dependencies
+#     run: |
+#       brew install openssl@3
+#       gem install fpm -v ${{env.fpmversion}}
+#       cd redis-stack
+#       poetry install
+#   - name: build redis from source
+#     if: steps.redis-already-built.outcome != 'success'
+#     run: |
+#       cd redis
+#       make all BUILD_TLS=yes FINAL_LIBS="-lm -ldl ../deps/hiredis/libhiredis_ssl.a /usr/local/opt/openssl/lib/libssl.a /usr/local/opt/openssl/lib/libcrypto.a"
+#
+#   - name: package redis for s3
+#     if: steps.redis-already-built.outcome != 'success'
+#     run: |
+#       mkdir redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}
+#       cp redis/src/redis-server \
+#           redis/src/redis-sentinel \
+#           redis/src/redis-check-aof \
+#           redis/src/redis-check-rdb \
+#           redis/src/redis-benchmark \
+#           redis/src/redis-cli \
+#           redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}
+#       tar -czvf redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz \
+#           redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}
+#
+#   - uses: s3-actions/s3cmd@v1.2.0
+#     with:
+#       provider: aws
+#       region: us-east-1
+#       access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#       secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#   - name: persist redis to s3
+#     if: steps.redis-already-built.outcome != 'success' && steps.iamafork.outputs.IAMAFORK == 'false'
+#     run: |
+#       s3cmd put -P redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz \
+#       s3://redismodules/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz
+#
+#   - name: perist redis
+#     if: steps.redis-already-built.outcome != 'success'
+#     uses: actions/upload-artifact@v3
+#     with:
+#       name: redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-osx
+#       path: |
+#         redis/src/redis-server
+#         redis/src/redis-sentinel
+#         redis/src/redis-check-aof
+#         redis/src/redis-check-rdb
+#         redis/src/redis-benchmark
+#         redis/src/redis-cli
+#
+#   - name: collect dependencies prior to zipping
+#     run: |
+#       cd redis-stack
+#       source .venv/bin/activate
+#       invoke package -o ${{env.osname}} -s ${{env.osnick}} -d ${{env.platform}} -a ${{env.arch}} -t zip -p redis-stack-server -k package
+#
+#   - name: codesign all binaries
+#     if: steps.iamafork.outputs.IAMAFORK == 'false'
+#     run: |
+#       cd redis-stack
+#       echo ${{secrets.MACOS_CERTIFICATE}} | base64 --decode > certificate.p12
+#       security create-keychain -p ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
+#       security default-keychain -s build.keychain
+#       security unlock-keychain -p ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
+#       security import certificate.p12 -k build.keychain -P ${{ secrets.MACOS_CERTIFICATE_PASSWORD }} -T /usr/bin/codesign
+#       security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
+#       CODESIGN_IDENTITY=`security find-identity -v|head -n 1|awk '{print $2}'`
+#       for i in `ls build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/bin`; do
+#         /usr/bin/codesign --options=runtime --timestamp -v --sign ${CODESIGN_IDENTITY} --entitlements etc/entitlements -f build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/bin/$i
+#       done
+#       for i in `ls build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/lib`; do
+#         /usr/bin/codesign --options=runtime --timestamp -v --sign ${CODESIGN_IDENTITY} --entitlements etc/entitlements -f build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/lib/$i
+#       done
+#
+#   - name: build the redis-stack-server zipfile (for homebrew)
+#     run: |
+#       cd redis-stack
+#       source .venv/bin/activate
+#       invoke package -o ${{env.osname}} -s ${{env.osnick}} -d ${{env.platform}} -a ${{env.arch}} -r ../redis/src -t zip -p redis-stack-server -k fetch
+#
+#   - name: perist the zipfile
+#     uses: actions/upload-artifact@v3
+#     with:
+#       name: redis-stack-${{env.platform}}-${{env.arch}}.${{env.target}}
+#       path: |
+#         redis-stack/redis-stack-*.zip
+#
+#   - name: create the zip for notarization
+#     run: |
+#       cd redis-stack/build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack
+#       zip -r notarized-${{env.platform}}-${{env.arch}}.zip bin lib
+#
+#   - name: notarize the custom zip
+#     if: steps.iamafork.outputs.IAMAFORK == 'false'
+#     run: |
+#       cd redis-stack/build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack
+#       sh ../../../../notarize.sh notarized-${{env.platform}}-${{env.arch}}.zip com.redis.redis-stack-server ${{ secrets.MAC_NOTARIZE_USERNAME }} ${{ secrets.MAC_NOTARIZE_PASSWORD }}
+#
+# test-osx-intel:
+#   name: Mac (x86_64) Tests
+#   needs: ['build-package-osx']
+#   runs-on: macos-latest
+#   env:
+#     arch: x86_64
+#     osnick: catalina
+#     target: zip
+#     platform: catalina
+#     osname: macos
+#     pythonversion: "3.10"
+#
+#   steps:
+#   - name: determine if in fork
+#     id: iamafork
+#     run: |
+#       amfork=`jq '.pull_request.head.repo.fork' $GITHUB_EVENT_PATH`
+#       echo "am I fork: ${amfork}"
+#       echo "IAMAFORK=$amfork" >> $GITHUB_OUTPUT
+#
+#   - name: install python
+#     uses: actions/setup-python@v4
+#     with:
+#       python-version: "${{ env.pythonversion }}"
+#   - name: install poetry
+#     uses: snok/install-poetry@v1
+#     with:
+#       version: latest
+#       virtualenvs-in-project: true
+#       virtualenvs-create: true
+#       installer-parallel: true
+#   - name: checkout sources
+#     uses: actions/checkout@v3
+#   - name: install dependencies
+#     run: |
+#       brew install libomp openssl coreutils
+#       poetry install
+#   - name: gather artifacts
+#     uses: actions/download-artifact@v3
+#     with:
+#       path: redis-stack
+#       name: redis-stack-${{env.platform}}-${{env.arch}}.${{env.target}}
+#   - name: unzip the zipfile
+#     run: |
+#       ls -R
+#       mkdir -p redis-stack
+#       unzip redis-stack/redis-stack*.${{env.target}} -d redis-stack/redis-stack-server
+#
+#   - name: run osx tests
+#     run: |
+#       .venv/bin/pytest -m macos --junit-xml=results.xml
+#   - uses: dorny/test-reporter@v1
+#     if: success() || failure()
+#     with:
+#       name: Test Results ${{env.platform}} ${{env.osnick}} ${{env.arch}}
+#       path: '*.xml'
+#       reporter: java-junit
+#       list-suites: all
+#       list-tests: all
+#       max-annotations: 10
+#
+#   - name: get package version
+#     id: get_version
+#     run: |
+#       poetry install
+#       source .venv/bin/activate
+#       realversion=`invoke version`
+#       echo "VERSION=$realversion" >> $GITHUB_OUTPUT
+#
+#   - uses: s3-actions/s3cmd@v1.2.0
+#     if: steps.iamafork.outputs.IAMAFORK == 'false'
+#     with:
+#       provider: aws
+#       region: us-east-1
+#       access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#       secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#
+#   - name: persist redis to s3
+#     if: steps.iamafork.outputs.IAMAFORK == 'false'
+#     run: |
+#      mkdir s3dist
+#      cp redis-stack/redis-stack*.${{env.target}} s3dist
+#      for i in `ls s3dist`; do
+#        sha256sum s3dist/$i | awk '{print $1}' > s3dist/$i.sha256
+#      done
+#      s3cmd put -P s3dist/* s3://redismodules/redis-stack/snapshots/
+#
+# # the m1 requires a zip file so that homebrew can unpack it
+# build-package-osx-m1:
+#   name: Mac (M1) Package
+#   env:
+#     arch: arm64
+#     osnick: monterey
+#     target: zip
+#     platform: monterey
+#     osname: macos
+#     pythonversion: "3.10"
+#     fpmversion: 1.14.2
+#     rubyversion: 2.7.2
+#   runs-on: macos-latest
+#   steps:
+#   - name: checkout sources
+#     uses: actions/checkout@v3
+#   - uses: ruby/setup-ruby@v1
+#     with:
+#       ruby-version: ${{env.rubyversion}}
+#   - name: install python
+#     uses: actions/setup-python@v4
+#     with:
+#       python-version: "${{ env.pythonversion }}"
+#   - name: install dependencies
+#     run: |
+#       brew install coreutils
+#   - name: install poetry
+#     uses: snok/install-poetry@v1
+#     with:
+#       version: latest
+#       virtualenvs-in-project: true
+#       virtualenvs-create: true
+#       installer-parallel: true
+#   - name: Cache dependencies
+#     uses: actions/cache@v3
+#     with:
+#       path: |
+#         /var/cache/apt/archives/**.deb
+#         ~/.cache/pip
+#         ~/.cache/pypoetry
+#         ~/.local/share/gem
+#       key: pypoetry-${{hashFiles('**/pyproject.toml')}}-${{env.platform}}-${{env.arch}}-package
+#   - name: install packaging tools
+#     run: |
+#       gem install fpm -v ${{env.fpmversion}}
+#       poetry install
+#
+#   - name: determine if in fork
+#     id: iamafork
+#     run: |
+#       amfork=`jq '.pull_request.head.repo.fork' $GITHUB_EVENT_PATH`
+#       echo "am I fork: ${amfork}"
+#       echo "IAMAFORK=$amfork" >> $GITHUB_OUTPUT
+#
+#   - name: write the ssh key to a file
+#     if: steps.iamafork.outputs.IAMAFORK == 'false'
+#     run: |
+#       echo "${{secrets.OPERETO_KEY}}" > ssh.key
+#       chmod 0400 ssh.key
+#
+#   - name: get versions from config file
+#     id: get_config_versions
+#     run: |
+#       echo PACKAGEDREDISVERSION=`grep -w "packagedredisversion" config.yml | cut -d ":" -f 2-2|tr -d ' '` >> $GITHUB_OUTPUT
+#       echo REDISVERSION=`grep -w "redis:" config.yml | cut -d ":" -f 2-2|tr -d ' '` >> $GITHUB_OUTPUT
+#
+#   - name: check if already built
+#     id: redis-already-built
+#     continue-on-error: true
+#     run: |
+#       wget -q https://redismodules.s3.amazonaws.com/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz
+#
+#   - name: build redis from source
+#     if: steps.redis-already-built.outcome != 'success' && steps.iamafork.outputs.IAMAFORK == 'false'
+#     run: |
+#       source .venv/bin/activate
+#       invoke build-m1-over-ssh \
+#        -i ${{ secrets.M1_IP }} \
+#        -u ${{ secrets.M1_SSH_USER }} \
+#        -s ssh.key \
+#        -v ${{ steps.get_config_versions.outputs.REDISVERSION }} \
+#        -p ${{ steps.get_config_versions.outputs.PACKAGEDREDISVERSION }}
+#
+#   - name: package redis for s3
+#     if: steps.redis-already-built.outcome != 'success'
+#     run: |
+#       tar -czvf redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz \
+#           redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}
+#   - uses: s3-actions/s3cmd@v1.2.0
+#     with:
+#       provider: aws
+#       region: us-east-1
+#       access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#       secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#
+#   - name: persist redis to s3
+#     if: steps.redis-already-built.outcome != 'success' && steps.iamafork.outputs.IAMAFORK == 'false'
+#     run: |
+#       s3cmd put -P redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz \
+#       s3://redismodules/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.osname}}-${{env.osnick}}-${{env.arch}}.tgz
+#
+#   - name: perist redis
+#     if: steps.redis-already-built.outcome != 'success'
+#     uses: actions/upload-artifact@v3
+#     with:
+#       name: redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{env.arch}}-osx
+#       path: |
+#         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-server
+#         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-sentinel
+#         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-check-aof
+#         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-check-rdb
+#         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-benchmark
+#         redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}*/redis-cli
+#
+#### Once https://github.com/actions/runner/issues/805 is resolved we can do this ###
+#### For now, this is how it is manually built, on the platform ###
+##    - name: build redis from source
+##      run: |
+##        cd redis
+##        make all BUILD_TLS=yes FINAL_LIBS="-lm -ldl ../deps/hiredis/libhiredis_ssl.a /opt/homebrew/opt/openssl/lib/libssl.a /opt/homebrew/opt/openssl/lib/libcrypto.a" CFLAGS="-I /opt/homebrew/opt/openssl@3/include"
+##
+#   - name: collect dependencies prior to packaging
+#     run: |
+#       source .venv/bin/activate
+#       invoke package -o ${{env.osname}} -s ${{env.osnick}} -d ${{env.platform}} -a ${{env.arch}} -t ${{env.target}} -p redis-stack-server -k package
+#
+#   - name: codesign all binaries
+#     if: steps.iamafork.outputs.IAMAFORK == 'false'
+#     run: |
+#       echo ${{secrets.MACOS_CERTIFICATE}} | base64 --decode > certificate.p12
+#       security create-keychain -p ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
+#       security default-keychain -s build.keychain
+#       security unlock-keychain -p ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
+#       security import certificate.p12 -k build.keychain -P ${{ secrets.MACOS_CERTIFICATE_PASSWORD }} -T /usr/bin/codesign
+#       security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k ${{ secrets.MACOS_KEYCHAIN_PASSWORD }} build.keychain
+#       CODESIGN_IDENTITY=`security find-identity -v|head -n 1|awk '{print $2}'`
+#       for i in `ls build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/bin`; do
+#         /usr/bin/codesign --options=runtime --timestamp -v --sign ${CODESIGN_IDENTITY} --entitlements etc/entitlements -f build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/bin/$i
+#       done
+#       for i in `ls build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/lib`; do
+#         /usr/bin/codesign --options=runtime --timestamp -v --sign ${CODESIGN_IDENTITY} --entitlements etc/entitlements -f build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/lib/$i
+#       done
+#
+#   - name: build redis-stack-server zipfile
+#     run: |
+#       source .venv/bin/activate
+#       invoke package -o ${{env.osname}} -s ${{env.osnick}} -d ${{env.platform}} -a ${{env.arch}} -t ${{env.target}} -p redis-stack-server -k fetch
+#       for i in `ls *.zip`; do
+#         sha256sum $i |awk '{print $1}' > $i.sha256
+#       done
+#
+#   - name: persist the zipfile
+#     uses: actions/upload-artifact@v3
+#     with:
+#       name: redis-stack-server-${{env.platform}}-${{env.arch}}.${{env.target}}
+#       path: |
+#         *.zip
+#
+#   - name: create the zip for notarization
+#     run: |
+#       cd build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack
+#       zip -r notarized-${{env.platform}}-${{env.arch}}.zip bin lib
+#
+#   - name: persist the codesigned artifacts
+#     uses: actions/upload-artifact@v3
+#     with:
+#       name: codesigned-${{env.platform}}-${{env.arch}}
+#       path: |
+#         build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack/*.zip
+#
+#   - name: notarize the custom zip
+#     if: steps.iamafork.outputs.IAMAFORK == 'false'
+#     run: |
+#       cd build/${{env.osname}}-${{env.osnick}}-${{env.arch}}.redis-stack-server/opt/redis-stack
+#       sh ../../../../notarize.sh notarized-${{env.platform}}-${{env.arch}}.zip com.redis.redis-stack-server ${{ secrets.MAC_NOTARIZE_USERNAME }} ${{ secrets.MAC_NOTARIZE_PASSWORD }}
+#
+#   - uses: s3-actions/s3cmd@v1.2.0
+#     if: steps.iamafork.outputs.IAMAFORK == 'false'
+#     with:
+#       provider: aws
+#       region: us-east-1
+#       access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#       secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#   - name: upload snapshots
+#     if: steps.iamafork.outputs.IAMAFORK == 'false'
+#     run: |
+#       s3cmd put -P *.${{env.target}} s3://redismodules/redis-stack/snapshots/
+#       s3cmd put -P *.sha256 s3://redismodules/redis-stack/snapshots/
+#
+# test-osx-m1:
+#   name: Mac (M1) tests
+#   needs: [build-package-osx-m1]
+#   env:
+#     arch: arm64
+#     osnick: monterey
+#     target: zip
+#     platform: monterey
+#     osname: macos
+#     pythonversion: "3.10"
+#   runs-on: ubuntu-latest
+#   steps:
+#     - name: determine if in fork
+#       id: iamafork
+#       run: |
+#         amfork=`jq '.pull_request.head.repo.fork' $GITHUB_EVENT_PATH`
+#         echo "am I fork: ${amfork}"
+#         echo "IAMAFORK=$amfork" >> $GITHUB_OUTPUT
+#
+#     - name: checkout sources
+#       uses: actions/checkout@v3
+#     - name: Cache dependencies
+#       uses: actions/cache@v3
+#       with:
+#         path: |
+#           /var/cache/apt/archives/**.deb
+#           ~/.cache/pip
+#           ~/.cache/pypoetry
+#           ~/.local/share/gem
+#           poetry.lock
+#         key: pypoetry-${{hashFiles('**/pyproject.toml')}}-${{env.platform}}-${{env.arch}}-package
+#     - name: install python
+#       uses: actions/setup-python@v4
+#       with:
+#         python-version: "${{ env.pythonversion }}"
+#     - name: install poetry
+#       uses: snok/install-poetry@v1
+#       with:
+#         version: latest
+#         virtualenvs-in-project: true
+#         virtualenvs-create: true
+#         installer-parallel: true
+#     - name: gather artifacts
+#       uses: actions/download-artifact@v3
+#       with:
+#         name: redis-stack-server-${{env.platform}}-${{env.arch}}.${{env.target}}
+#
+#     - name: write the ssh key to a file
+#       if: steps.iamafork.outputs.IAMAFORK == 'false'
+#       run: |
+#         echo "${{secrets.OPERETO_KEY}}" > ssh.key
+#         chmod 0400 ssh.key
+#
+#     - name: get package version
+#       id: get_version
+#       run: |
+#         poetry install
+#         source .venv/bin/activate
+#         realversion=`invoke version`
+#         echo "VERSION=$realversion" >> $GITHUB_OUTPUT
+#
+#     - name: run the tests
+#       if: steps.iamafork.outputs.IAMAFORK == 'false'
+#       run: |
+#         source .venv/bin/activate
+#         invoke test-over-ssh -b \
+#           redis-stack-server-${{steps.get_version.outputs.VERSION}}.${{env.platform}}.${{env.arch}}.${{env.target}} \
+#           -i ${{secrets.M1_IP}} \
+#           -m macos \
+#           -p redis-stack-server \
+#           -s ssh.key \
+#           -u ${{secrets.M1_SSH_USER}} \
+#           -v `echo $RANDOM` \
+#           -g ${{github.head_ref}}
 
 ###################### COLLATE DOCKERS ##################
  docker-push:


### PR DESCRIPTION
The docker builds fail, due to docker notiing that an image is a manifest. The docker API notes, when pulling edge dockers that edge-x86_64 is a manifest - though it's clearly an image. When running an inspect on an image, or pulling via tag, or sha - docker reports that ```Error: No such image: redisfab/redis-stack-server:edge-x86_64```, yet in other cases, indicates that this is a manifest.