### PR TITLE
Fixing arm on-target compilation

### DIFF
--- a/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
+++ b/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
@@ -104,10 +104,10 @@ jobs:
       uses: uraimo/run-on-arch-action@v2
       with:
         arch: aarch64
-        distro: ubuntu18.04
+        distro: ${{inputs.osnick}}
         install: ${{inputs.build_deps}}
         run: |
-          make -C redis/src all BUILD_TLS=yes MALLOC=libc
+          make -C redis/src all BUILD_TLS=yes MALLOC=libc CFLAGS="-static" LDFLAGS="-static"
     - name: package redis for s3
       if: steps.redis-already-built.outcome != 'success'
       run: |

--- a/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
+++ b/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
@@ -41,6 +41,9 @@ on:
       moduleoverride:
         required: false
         type: string
+      redislinkflags:
+        required: false
+        type: string
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -107,7 +110,7 @@ jobs:
         distro: ${{inputs.osnick}}
         install: ${{inputs.build_deps}}
         run: |
-          make -C redis/src all BUILD_TLS=yes MALLOC=libc CFLAGS="-static" LDFLAGS="-static"
+          make -C redis/src all BUILD_TLS=yes MALLOC=libc CFLAGS="-static" LDFLAGS="-static ${{inputs.redislinkflags}}"
     - name: package redis for s3
       if: steps.redis-already-built.outcome != 'success'
       run: |

--- a/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
+++ b/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
@@ -110,7 +110,7 @@ jobs:
         distro: ${{inputs.osnick}}
         install: ${{inputs.build_deps}}
         run: |
-          make -C redis/src all BUILD_TLS=yes MALLOC=libc CFLAGS="-static" LDFLAGS="-static ${{inputs.redislinkflags}}"
+          make -C redis/src all BUILD_TLS=yes MALLOC=libc
     - name: package redis for s3
       if: steps.redis-already-built.outcome != 'success'
       run: |

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -29,7 +29,6 @@ jobs:
      target: deb
      build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip
      pythonversion: "3.10"
-     redislinkflags: "-ldl"
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -48,7 +47,6 @@ jobs:
      target: deb
      build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip
      pythonversion: "3.10"
-     redislinkflags: "-ldl"
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -64,7 +62,7 @@ jobs:
      osnick: ubuntu22.04
      arch: arm64
      target: deb
-     build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip
+     build_deps: apt-get update && apt-get upgrade -y && apt-get install -y build-essential libssl-dev python3 python3-pip
      pythonversion: "3.10"
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -29,6 +29,7 @@ jobs:
      target: deb
      build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip
      pythonversion: "3.10"
+     redislinkflags: "-ldl"
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -47,6 +48,7 @@ jobs:
      target: deb
      build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip
      pythonversion: "3.10"
+     redislinkflags: "-ldl"
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/config.yml
+++ b/config.yml
@@ -12,11 +12,11 @@ versions:
   nodejs: v16.15.1
 
   # the redis repository tag
-  redis: 7.0.7
+  redis: 7.0.8
 
   # the version of the package we build and track (separate, in case changes are needed)
   # as in the past
-  packagedredisversion: 7.0.7-1
+  packagedredisversion: 7.0.8-2
   redis-stack: 99.99.99
   redis-stack-server: 99.99.99
   redisinsight: 2.18.0

--- a/config.yml
+++ b/config.yml
@@ -16,7 +16,7 @@ versions:
 
   # the version of the package we build and track (separate, in case changes are needed)
   # as in the past
-  packagedredisversion: 7.0.8-2
+  packagedredisversion: 7.0.8-3
   redis-stack: 99.99.99
   redis-stack-server: 99.99.99
   redisinsight: 2.18.0


### PR DESCRIPTION
This PR tries to fix the issue where the ARM build, for redis was tied to ubuntu18.04. It led to a bug where some Ubuntu ARM instances, due to the verison of libssl, redis-stack woudl fail to start. As a side benefit this should also make it easy to support more platforms in the future.