### PR TITLE
APPImage build fix

### DIFF
--- a/.github/workflows/APPIMAGE_REUSABLE.yml
+++ b/.github/workflows/APPIMAGE_REUSABLE.yml
@@ -109,7 +109,7 @@ jobs:
           cat VERSION
       - name: build appimage
         run: |
-          ./pkg2appimage.AppImage `pwd`/etc/redis-stack-server.appimage
+          ./pkg2appimage--${{inputs.arch}}.AppImage `pwd`/etc/redis-stack-server.appimage
           mv out/redis-stack-server-*.AppImage out/${{matrix.package}}-${{steps.get_version.outputs.VERSION}}-${{inputs.arch}}.AppImage
           for i in `ls out/*.AppImage`; do
             sha256sum $i | awk '{print $1}' > $i.sha256

--- a/.github/workflows/APPIMAGE_REUSABLE.yml
+++ b/.github/workflows/APPIMAGE_REUSABLE.yml
@@ -90,7 +90,7 @@ jobs:
           poetry install
       - name: fetch dependencies
         run: |
-          wget -q https://github.com/AppImage/pkg2appimage/releases/download/continuous/pkg2appimage-${{inputs.pkg2appimageversion}}-${{inputs.arch}}.AppImage -O pkg2appimage.AppImage
+          wget -c $(wget -q https://api.github.com/repos/AppImageCommunity/pkg2appimage/releases -O - | grep "pkg2appimage-.*-${{inputs.arch}}.AppImage" | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
           chmod a+x *.AppImage
       - name: fetch artifacts
         uses: actions/download-artifact@v3


### PR DESCRIPTION
It appears that the releases for pkg2app were yanked. This PR attempts to use *current* always.