### PR TITLE
Updating master module versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ invoke package -o Linux -p redis-stack-server -s ubuntu16.04 -t deb -d xenial
 
 *To build a macos (x86_64) zip, prior to homebrew*
 ```
-invoke package -o macos -p redis-stack-server -s catalina -t zip -d catalina
+invoke package -o macos -p redis-stack-server -s monterey -t zip -d monterey
 ```
 
 *To build a macos (m1) zip, prior to homebrew*

--- a/config.yml
+++ b/config.yml
@@ -6,9 +6,9 @@ islatest: no
 versions:
   rejson: 2.6.6
   redistimeseries: 1.10.4
-  redisearch: 2.8.4
+  redisearch: 2.8.8
   redisbloom: 2.6.3
-  redisgears: 2.0.11
+  redisgears: 2.0.13
   redisgraph: 2.10.12
   nodejs: v16.15.1
 
@@ -20,8 +20,8 @@ versions:
   packagedredisversion: 7.2.1-1
   redis-stack: 99.99.99
   redis-stack-server: 99.99.99
-  redisinsight: 2.32.0
-  redisinsight-web: 2.32.0
+  redisinsight: 2.34.0
+  redisinsight-web: 2.34.0
 
 # common package variables
 email: Redis OSS <oss@redislabs.com>

--- a/stack/components/modules.py
+++ b/stack/components/modules.py
@@ -42,7 +42,7 @@ class Modules(object):
         # HACK FIXME
         # until the monterey/catalina issue can be resolved upstream, we're going to handle it in packaging
         # in order to get the release out
-        if module in ["redisearch"] and self.ARCH == "x86_64" and self.OSNAKE == 'macos':
+        if module in ["redisearch"] and self.ARCH == "x86_64" and self.OSNAME == 'macos':
             osnick = "monterey"
             logger.warning(
                 f"HACK: OVERRIDING with {osnick} until this can be fixed in the modules"

--- a/stack/components/modules.py
+++ b/stack/components/modules.py
@@ -39,6 +39,15 @@ class Modules(object):
         """Assuming the module follows the standard, return the URL from
         which to grab it"""
 
+        # HACK FIXME
+        # until the monterey/catalina issue can be resolved upstream, we're going to handle it in packaging
+        # in order to get the release out
+        if module in ['redisearch'] and self.ARCH == "x86_64":
+            osnick = "monterey"
+            logger.warning(f"HACK: OVERRIDING with {osnick} until this can be fixed in the modules")
+        else:
+            osnick = self.OSNICK
+
         if module == "redisearch":
             module = "redisearch-oss"
 
@@ -46,7 +55,7 @@ class Modules(object):
             module = "rejson-oss"
 
         # one day, get the version like others, into gears
-        mod_url_part = f"{module}.{self.OSNAME}-{self.OSNICK}-{self.ARCH}.{version}.zip"
+        mod_url_part = f"{module}.{self.OSNAME}-{osnick}-{self.ARCH}.{version}.zip"
         if module == "redisgears" and self.OSNAME == "macos" and self.ARCH == "x86_64":
             mod_url_part = f"{module}.Macos-mac_os11.4.0-{self.ARCH}.{version}.zip"
         elif (

--- a/stack/components/modules.py
+++ b/stack/components/modules.py
@@ -42,9 +42,11 @@ class Modules(object):
         # HACK FIXME
         # until the monterey/catalina issue can be resolved upstream, we're going to handle it in packaging
         # in order to get the release out
-        if module in ['redisearch'] and self.ARCH == "x86_64":
+        if module in ["redisearch"] and self.ARCH == "x86_64" and self.OSNAKE == 'macos':
             osnick = "monterey"
-            logger.warning(f"HACK: OVERRIDING with {osnick} until this can be fixed in the modules")
+            logger.warning(
+                f"HACK: OVERRIDING with {osnick} until this can be fixed in the modules"
+            )
         else:
             osnick = self.OSNICK
 


### PR DESCRIPTION
Updating the module and RI versions in master. Note - supporting the redisjson compiile issue with binaries that do not match names - as the modules release new, matching names. For now - we can solve that in packaging.

A new PR will be open for #462

closes #462 
closes #463 