### PR TITLE
NodeJS bump for RedisInsight, just to test

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,7 +10,7 @@ versions:
   redisbloom: 2.6.3
   redisgears: 2.0.13
   redisgraph: 2.10.12
-  nodejs: v16.15.1
+  nodejs: v18.18.0
 
   # the redis repository tag
   redis: 7.2.1


### PR DESCRIPTION
After speaking with Viktar, this passes - merge to master and let's roll to 7.2 latest