### PR TITLE
Adding openssl1.1 libraries for gears, on amazonlinux2

### DIFF
--- a/.github/workflows/APPIMAGE_REUSABLE.yml
+++ b/.github/workflows/APPIMAGE_REUSABLE.yml
@@ -87,7 +87,7 @@ jobs:
       - name: install packaging tools
         run: |
           gem install fpm -v ${{inputs.fpmversion}}
-          poetry install
+          poetry install --no-root
       - name: fetch dependencies
         run: |
           wget -c $(wget -q https://api.github.com/repos/AppImageCommunity/pkg2appimage/releases -O - | grep "pkg2appimage-.*-${{inputs.arch}}.AppImage" | grep browser_download_url | head -n 1 | cut -d '"' -f 4)
@@ -101,7 +101,7 @@ jobs:
       - name: get package version
         id: get_version
         run: |
-          poetry install
+          poetry install --no-root
           source .venv/bin/activate
           realversion=`invoke version -p redis-stack-server`
           echo "VERSION=$realversion" >> $GITHUB_OUTPUT

--- a/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
+++ b/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
@@ -205,7 +205,7 @@ jobs:
          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
          sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
          sudo apt-get update && sudo apt-get install vagrant virtualbox
-         poetry install
+         poetry install --no-root
 
      - name: install qemu
        uses: docker/setup-qemu-action@v2

--- a/.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+++ b/.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
@@ -227,7 +227,7 @@ jobs:
           curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
           sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
           sudo apt-get update && sudo apt-get install vagrant virtualbox
-          poetry install
+          poetry install --no-root
 
       - run: gem install fpm -v ${{env.fpmversion}}
 
@@ -409,7 +409,7 @@ jobs:
 #        run: |
 #          python -m venv .venv
 #          source .venv/bin/activate
-#          poetry install
+#          poetry install --no-root
 #      - name: get package version
 #        id: get_version
 #        run: |

--- a/.github/workflows/DOCKER_REUSABLE.yml
+++ b/.github/workflows/DOCKER_REUSABLE.yml
@@ -77,7 +77,7 @@ jobs:
       - name: get package version
         id: get_version
         run: |
-          poetry install
+          poetry install --no-root
           source .venv/bin/activate
           realversion=`invoke version -p ${{ matrix.package }} -d true`
           echo "VERSION=$realversion" >> $GITHUB_OUTPUT

--- a/.github/workflows/REDISINSIGHT_WEB_REUSABLE.yml
+++ b/.github/workflows/REDISINSIGHT_WEB_REUSABLE.yml
@@ -84,7 +84,7 @@ jobs:
        run: |
          sudo apt-get update
          sudo apt-get install unzip libterm-readkey-perl dpkg-sig
-         poetry install
+         poetry install --no-root
      - run: gem install fpm -v ${{env.fpmversion}}
      - name: build redisinsight-web
        run: |

--- a/.github/workflows/SNAP_REUSABLE.yml
+++ b/.github/workflows/SNAP_REUSABLE.yml
@@ -78,7 +78,7 @@ jobs:
       - name: install packaging tools
         run: |
           gem install fpm -v ${{inputs.fpmversion}}
-          poetry install
+          poetry install --no-root
       - name: build snap
         run: |
           source .venv/bin/activate

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -309,7 +309,7 @@ jobs:
      GPG_KEY: ${{ secrets.GPG_KEY }}
      GPG_PASSWORD: ${{ secrets.GPG_PASSWORD }}
 
-# Commented out as RedisGraph is not compatible with RHEL9. 
+# Commented out as RedisGraph is not compatible with RHEL9.
 # The merge of rediscompat was not carried out due to client side support for redisgraph, during the deprecation phase.
 #  x86-64_rhel9:
 #    uses: ./.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
@@ -401,7 +401,7 @@ jobs:
        brew install openssl@3
        gem install fpm -v ${{env.fpmversion}}
        cd redis-stack
-       poetry install
+       poetry install --no-root
    - name: build redis from source
      if: steps.redis-already-built.outcome != 'success'
      run: |
@@ -531,7 +531,7 @@ jobs:
    - name: install dependencies
      run: |
        brew install libomp openssl coreutils
-       poetry install
+       poetry install --no-root
    - name: gather artifacts
      uses: actions/download-artifact@v3
      with:
@@ -559,7 +559,7 @@ jobs:
    - name: get package version
      id: get_version
      run: |
-       poetry install
+       poetry install --no-root
        source .venv/bin/activate
        realversion=`invoke version`
        echo "VERSION=$realversion" >> $GITHUB_OUTPUT
@@ -627,7 +627,7 @@ jobs:
    - name: install packaging tools
      run: |
        gem install fpm -v ${{env.fpmversion}}
-       poetry install
+       poetry install --no-root
 
    - name: determine if in fork
      id: iamafork
@@ -827,7 +827,7 @@ jobs:
      - name: get package version
        id: get_version
        run: |
-         poetry install
+         poetry install --no-root
          source .venv/bin/activate
          realversion=`invoke version`
          echo "VERSION=$realversion" >> $GITHUB_OUTPUT
@@ -872,7 +872,7 @@ jobs:
      - name: get package version
        id: get_version
        run: |
-         poetry install
+         poetry install --no-root
          source .venv/bin/activate
          realversion=`invoke version -p ${{ matrix.package }} -d true`
          echo "VERSION=$realversion" >> $GITHUB_OUTPUT

--- a/stack/recipes/__init__.py
+++ b/stack/recipes/__init__.py
@@ -91,6 +91,8 @@ class Recipe(object):
         fpmargs.append("--depends openssl-devel")
         fpmargs.append("--depends jemalloc-devel")
         fpmargs.append("--depends libgomp")
+        if self.OSNICK == "amzn2":
+            fpmargs.append("--depends openssl11-libs")
         fpmargs.append(
             f"-p {self.C.get_key(self.PACKAGE_NAME)['product']}-{self.version}.{distribution}.{self.ARCH}.rpm"
         )

--- a/tests/smoketest/test_rpms.py
+++ b/tests/smoketest/test_rpms.py
@@ -62,6 +62,12 @@ class TestAmazonLinux2(RPMTestBase):
         res, out = container.exec_run("iamnotarealcommand")
         assert res != 0
 
+        res, out = container.exec_run(
+            "yum install -y openssl11-libs",
+        )
+        if res != 0:
+            raise IOError(out)
+
         # now, install our package
         res, out = container.exec_run(
             "yum install -y /build/redis-stack/redis-stack-server.rpm"

--- a/tests/smoketest/test_tars.py
+++ b/tests/smoketest/test_tars.py
@@ -174,7 +174,7 @@ class TestAmazonLinuxTar(TARTestBase):
 
         return [
             "amazon-linux-extras install epel -y",
-            "yum install -y openssl-devel jemalloc-devel libgomp tar gzip",
+            "yum install -y openssl-devel openssl11-libs jemalloc-devel libgomp tar gzip",
         ]
 
 @pytest.mark.rhel9


### PR DESCRIPTION
This pull request adds support for openssl1.1-libs on amazonlinux2, as it's required, for supporting gears in a cluster. As part of this change, it was discovered that an upstream change to poetry necessitates passing in --no-root, in order to ensure the redis-stack tooling package itself, is not installed as part of the poetry install process. This last change, is a safety net, more than a requirement - for our use case.