### PR TITLE
Redis unstable in redis-stack:edge dockers

### DIFF
--- a/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
+++ b/.github/workflows/ARM_BUILD_AND_PACKAGE_REUSABLE.yml
@@ -41,9 +41,15 @@ on:
       moduleoverride:
         required: false
         type: string
-      redislinkflags:
+
+      # if set to true, then replace the redis version, and ignore if built
+      # this is used by the master nightly, to bring us a redis unstable edge
+      forcebuildredis:
         required: false
-        type: string
+        type: boolean
+        default: false
+
+
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -89,7 +95,7 @@ jobs:
       run: |
         wget -q https://redismodules.s3.amazonaws.com/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{inputs.osname}}-${{inputs.osnick}}-${{inputs.arch}}.tgz
     - uses: actions/checkout@v3
-      if: steps.redis-already-built.outcome != 'success'
+      if: steps.redis-already-built.outcome != 'success' || ${{inputs.forcebuildredis}}
       with:
         repository: redis/redis
         path: redis
@@ -103,7 +109,7 @@ jobs:
           /var/cache/yum
         key: cache-${{hashFiles('.github/workflows/redis.yml')}}-${{inputs.platform}}-${{inputs.arch}}-build
     - name: make
-      if: steps.redis-already-built.outcome != 'success'
+      if: steps.redis-already-built.outcome != 'success' || ${{inputs.forcebuildredis}}
       uses: uraimo/run-on-arch-action@v2
       with:
         arch: aarch64
@@ -112,7 +118,7 @@ jobs:
         run: |
           make -C redis/src all BUILD_TLS=yes MALLOC=libc
     - name: package redis for s3
-      if: steps.redis-already-built.outcome != 'success'
+      if: steps.redis-already-built.outcome != 'success' || ${{inputs.forcebuildredis}}
       run: |
         mkdir redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{inputs.osname}}-${{inputs.osnick}}-${{inputs.arch}}
         cp redis/src/redis-server \
@@ -125,18 +131,18 @@ jobs:
         tar -czvf redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{inputs.osname}}-${{inputs.osnick}}-${{inputs.arch}}.tgz \
            redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{inputs.osname}}-${{inputs.osnick}}-${{inputs.arch}}
     - name: install s3cmd
-      if: steps.redis-already-built.outcome != 'success'
+      if: steps.redis-already-built.outcome != 'success' || ${{inputs.forcebuildredis}}
       run: |
         pip3 install s3cmd
     - name: persist redis to s3
-      if: steps.redis-already-built.outcome != 'success' && steps.iamafork.outputs.IAMAFORK == 'false'
+      if: (steps.redis-already-built.outcome != 'success' || ${{inputs.forcebuildredis}}) && steps.iamafork.outputs.IAMAFORK == 'false'
       run: |
         s3cmd --access_key=${{secrets.AWS_ACCESS_KEY_ID}} --secret_key=${{secrets.AWS_SECRET_ACCESS_KEY}} --region=us-east-1 put -P redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{inputs.osname}}-${{inputs.osnick}}-${{inputs.arch}}.tgz \
           s3://redismodules/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{inputs.osname}}-${{inputs.osnick}}-${{inputs.arch}}.tgz
 
     - name: perist redis
       uses: actions/upload-artifact@v3
-      if: steps.redis-already-built.outcome != 'success'
+      if: steps.redis-already-built.outcome != 'success' || ${{inputs.forcebuildredis}}
       with:
         name: redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{inputs.platform}}-${{inputs.arch}}
         path: |

--- a/.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
+++ b/.github/workflows/BUILD_AND_PACKAGE_REUSABLE.yml
@@ -64,6 +64,13 @@ on:
         required: false
         type: string
 
+      # if set to true, then replace the redis version, and ignore if built
+      # this is used by the master nightly, to bring us a redis unstable edge
+      forcebuildredis:
+        required: false
+        type: boolean
+        default: false
+
     # for AWS and code signing
     secrets:
       AWS_ACCESS_KEY_ID:
@@ -115,7 +122,7 @@ jobs:
       run: |
         wget -q https://redismodules.s3.amazonaws.com/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{inputs.osname}}-${{inputs.osnick}}-${{inputs.arch}}.tgz
     - uses: actions/checkout@v3
-      if: steps.redis-already-built.outcome != 'success'
+      if: steps.redis-already-built.outcome != 'success' || ${{inputs.forcebuildredis}}
       with:
         repository: redis/redis
         path: redis
@@ -128,10 +135,11 @@ jobs:
           /var/cache/yum
         key: cache-${{hashFiles('.github/workflows/*.yml')}}-${{inputs.platform}}-${{inputs.testplatform}}-${{inputs.arch}}-build
     - name: make
-      if: steps.redis-already-built.outcome != 'success'
+      if: steps.redis-already-built.outcome != 'success' || ${{inputs.forcebuildredis}}
       run: JEMALLOC_CONFIGURE_OPTS="--with-lg-page=16" make -C redis/src all BUILD_TLS=yes
+
     - name: package redis for s3
-      if: steps.redis-already-built.outcome != 'success'
+      if: steps.redis-already-built.outcome != 'success' || ${{inputs.forcebuildredis}}
       run: |
         mkdir redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{inputs.osname}}-${{inputs.osnick}}-${{inputs.arch}}
         cp redis/src/redis-server \
@@ -144,17 +152,17 @@ jobs:
         tar -czvf redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{inputs.osname}}-${{inputs.osnick}}-${{inputs.arch}}.tgz \
            redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{inputs.osname}}-${{inputs.osnick}}-${{inputs.arch}}
     - name: install s3cmd
-      if: steps.redis-already-built.outcome != 'success'
+      if: steps.redis-already-built.outcome != 'success' || ${{inputs.forcebuildredis}}
       run: |
         pip3 install s3cmd
     - name: persist redis to s3
-      if: steps.redis-already-built.outcome != 'success' && steps.iamafork.outputs.IAMAFORK == 'false'
+      if: (steps.redis-already-built.outcome != 'success' || ${{inputs.forcebuildredis}}) && steps.iamafork.outputs.IAMAFORK == 'false'
       run: |
         s3cmd --access_key=${{secrets.AWS_ACCESS_KEY_ID}} --secret_key=${{secrets.AWS_SECRET_ACCESS_KEY}} --region=us-east-1 put -P redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{inputs.osname}}-${{inputs.osnick}}-${{inputs.arch}}.tgz \
           s3://redismodules/redis-stack/dependencies/redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{inputs.osname}}-${{inputs.osnick}}-${{inputs.arch}}.tgz
 
     - name: perist redis
-      if: steps.redis-already-built.outcome != 'success'
+      if: steps.redis-already-built.outcome != 'success' || ${{inputs.forcebuildredis}}
       uses: actions/upload-artifact@v3
       with:
         name: redis-${{steps.get_config_versions.outputs.PACKAGEDREDISVERSION}}-${{inputs.platform}}

--- a/.github/workflows/nightly-edge-docker.yml
+++ b/.github/workflows/nightly-edge-docker.yml
@@ -47,6 +47,7 @@ jobs:
      build_deps: apt-get update && apt-get upgrade -y && apt-get install -y build-essential libssl-dev python3 python3-pip
      pythonversion: "3.10"
      moduleoverride: master
+     forcebuildredis: true
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -92,6 +93,7 @@ jobs:
      build_deps: apt-get update && apt-get install -y build-essential libssl-dev python3 python3-pip jq wget
      pythonversion: "3.10"
      moduleoverride: master
+     forcebuildredis: true
    secrets:
      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/config.yml
+++ b/config.yml
@@ -14,11 +14,11 @@ versions:
   nodejs: v18.18.1
 
   # the redis repository tag
-  redis: 7.2.4
+  redis: unstable
 
   # the version of the package we build and track (separate, in case changes are needed)
   # as in the past
-  packagedredisversion: 7.2.4-1
+  packagedredisversion: unstable
   redis-stack: 99.99.99
   redis-stack-server: 99.99.99
   redisinsight: 2.40.0


### PR DESCRIPTION
The purpose of this PR is to make it easier to test newer features of redis, via the edge docker. The edge docker of redis stack, will now contain the latest builds of the components, with the latest build of redis, freshly cloned from the redis repository. Given the portability of the GitHub actions, this means that:

These changes should be mergeable to other branches.
Only the nightly build of the docker is impacted.

This goal is achieved by introducing a new  variable within the reusable jobs.
