### PR TITLE
Added version override for RedisCompat

### DIFF
--- a/stack/components/modules.py
+++ b/stack/components/modules.py
@@ -90,12 +90,9 @@ class Modules(object):
         self._run("rejson", version, override)
 
     def rediscompat(self, version: Union[str, None] = None):
-        """rejson specific fetch"""
-        if version is None:
-            version = self.C.get_key("versions")["rediscompat"]
-            override = False
-        else:
-            override = True
+        """rediscompat specific fetch"""
+        version = self.C.get_key("versions")["rediscompat"]
+        override = False
         self._run("rediscompat", version, override)
 
     def redisgears(self, version: Union[str, None] = None):


### PR DESCRIPTION
Since only one version is available for RedisCompat anything else should be overriden